### PR TITLE
feat: Add /api/sounds/play-stream for piping audio directly

### DIFF
--- a/lib/soundboard_web/controllers/api/sound_controller.ex
+++ b/lib/soundboard_web/controllers/api/sound_controller.ex
@@ -67,6 +67,60 @@ defmodule SoundboardWeb.API.SoundController do
     }
   end
 
+
+  @doc """
+  Play audio piped directly as raw binary data.
+
+  Usage:
+    curl -X POST "https://api.elevenlabs.io/v1/text-to-speech/VOICE_ID" \
+      -H "xi-api-key: KEY" -d '{"text": "Hello"}' | \
+    curl -X POST "/api/sounds/play-stream" \
+      -H "Authorization: Bearer ..." \
+      -H "Content-Type: audio/mpeg" \
+      --data-binary @-
+  """
+  def play_stream(conn, _params) do
+    username =
+      case conn.assigns[:current_user] do
+        %Soundboard.Accounts.User{username: uname} -> uname
+        _ -> get_req_header(conn, "x-username") |> List.first() || "API User"
+      end
+
+    volume =
+      (conn.query_params["volume"] || get_req_header(conn, "x-volume") |> List.first() || "1.0")
+      |> parse_float()
+
+    content_type = get_req_header(conn, "content-type") |> List.first() || "audio/mpeg"
+    ext = case content_type do
+      "audio/mpeg" -> "mp3"
+      "audio/mp3" -> "mp3"
+      "audio/wav" -> "wav"
+      "audio/ogg" -> "ogg"
+      _ -> "mp3"
+    end
+
+    {:ok, audio_data, conn} = Plug.Conn.read_body(conn)
+
+    if byte_size(audio_data) > 0 do
+      filename = "stream_#{:crypto.strong_rand_bytes(8) |> Base.encode16(case: :lower)}.#{ext}"
+      temp_path = Path.join(System.tmp_dir!(), filename)
+      File.write!(temp_path, audio_data)
+
+      SoundboardWeb.AudioPlayer.play_url(temp_path, volume, username)
+
+      Task.start(fn ->
+        Process.sleep(30_000)
+        File.rm(temp_path)
+      end)
+
+      json(conn, %{status: "success", message: "Playing streamed audio", played_by: username})
+    else
+      conn
+      |> put_status(:bad_request)
+      |> json(%{error: "No audio data received"})
+    end
+  end
+
   defp current_tenant(conn) do
     conn.assigns[:current_tenant] || Tenants.ensure_default_tenant!()
   end
@@ -81,4 +135,12 @@ defmodule SoundboardWeb.API.SoundController do
   end
 
   defp normalize_id(_), do: -1
+
+  defp parse_float(val) when is_binary(val) do
+    case Float.parse(val) do
+      {f, _} -> f
+      :error -> 1.0
+    end
+  end
+  defp parse_float(_), do: 1.0
 end

--- a/lib/soundboard_web/router.ex
+++ b/lib/soundboard_web/router.ex
@@ -82,6 +82,7 @@ defmodule SoundboardWeb.Router do
 
     get "/sounds", SoundController, :index
     post "/sounds/:id/play", SoundController, :play
+    post "/sounds/play-stream", SoundController, :play_stream
     post "/sounds/stop", SoundController, :stop
   end
 


### PR DESCRIPTION
Adds endpoint to play audio piped directly to SoundBored, perfect for TTS integration.

## Usage
```bash
curl -X POST "https://api.elevenlabs.io/v1/text-to-speech/VOICE" \
  -H "xi-api-key: KEY" -d '{"text": "Hello"}' | \
curl -X POST "/api/sounds/play-stream" \
  -H "Authorization: Bearer ..." \
  -H "Content-Type: audio/mpeg" --data-binary @-
```

## Features
- Accepts raw audio binary via POST body
- Auto-detects format from Content-Type header
- Optional volume via `?volume=0.8` query param or `X-Volume` header
- Temp file auto-cleanup after 30 seconds

## Use Case
ElevenLabs TTS → pipe → SoundBored → Discord voice chat