### PR TITLE
Fix stale voice session recovery with leave→rejoin

### DIFF
--- a/lib/soundboard/audio_player/voice_session.ex
+++ b/lib/soundboard/audio_player/voice_session.ex
@@ -65,10 +65,17 @@ defmodule Soundboard.AudioPlayer.VoiceSession do
 
   defp perform_maintenance(%{joined?: true} = status, state) do
     Logger.warning(
-      "Voice session unready for guild #{status.guild_id} in channel #{status.channel_id}, attempting refresh"
+      "Voice session unready for guild #{status.guild_id} in channel #{status.channel_id}, forcing leave→rejoin"
     )
 
-    attempt_voice_join(state, status.guild_id, status.channel_id, "refresh")
+    try do
+      Voice.leave_channel(status.guild_id)
+    rescue
+      error -> Logger.warning("Voice leave failed during reset: #{inspect(error)}")
+    end
+
+    Process.sleep(1_000)
+    attempt_voice_join(state, status.guild_id, status.channel_id, "rejoin after stale session")
   end
 
   defp perform_maintenance(status, state) do

--- a/test/soundboard_web/audio_player_test.exs
+++ b/test/soundboard_web/audio_player_test.exs
@@ -34,13 +34,15 @@ defmodule Soundboard.AudioPlayerTest do
       channel_id: fn "guild-1" -> "channel-1" end,
       ready?: fn "guild-1" -> false end,
       playing?: fn "guild-1" -> raise "playback status unavailable" end,
+      leave_channel: fn "guild-1" -> :ok end,
       join_channel: fn "guild-1", "channel-1" ->
         send(test_pid, :join_attempted)
         :ok
       end do
       send(AudioPlayer, :check_voice_connection)
 
-      assert_receive :join_attempted
+      # leave→rejoin includes a 1s sleep between leave and join
+      assert_receive :join_attempted, 2_000
     end
   end
 end


### PR DESCRIPTION
## Problem

When the bot sits in a Discord voice channel overnight, Discord rotates voice/DAVE encryption credentials. The maintenance loop detected the session as `joined but not ready` and re-sent OP4 join — which Discord ignores since the bot is already connected. This caused:

- `Voice session unready` warnings every 30s for hours
- `Voice encryption not ready yet` retries on playback attempts  
- `Exceeded max retries` errors — sounds fail to play until manual leave/rejoin

## Fix

Replace the no-op soft join with a full `leave → 1s sleep → rejoin` cycle in the maintenance loop. The 30-second interval acts as a natural rate limiter (no new state/counters needed).

## Changes

- `voice_session.ex`: `perform_maintenance` for `joined? and not ready?` now does leave→rejoin
- `audio_player_test.exs`: added `leave_channel` mock + bumped assert timeout for 1s sleep

## Testing

- 275 tests, 0 failures
- Credo strict: no issues
- Format: clean