### PR TITLE
Voice channel mode enum: auto-join, idle leave

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,18 @@ DISCORD_CLIENT_SECRET=your_client_secret_here
 PHX_HOST=localhost
 SCHEME=http
 SECRET_KEY_BASE=generate_with_mix_phx_gen_secret_or_openssl_rand
-# Voice channel behaviour (enable explicitly when desired)
-AUTO_JOIN=false
+# Set to 0.0.0.0 to bind to all interfaces (e.g. when running in Docker dev)
+BIND_IP=127.0.0.1
+# Voice channel join mode: play (default), presence, or false
+#   play     - bot joins when you play a sound; leaves when last user leaves or on idle timeout
+#   presence - bot follows users into channels; leaves when last user leaves
+#   false    - manual !join only; leaves after idle timeout once all users have left
+AUTO_JOIN=play
+# Seconds of inactivity before the bot auto-leaves (default: 600). Set to 0 to disable.
+# In 'play' mode: timer resets on each sound; bot also leaves when last user leaves.
+# In 'false' mode: timer starts after the last user leaves.
+# In 'presence' mode: ignored (bot leaves when last user leaves).
+VOICE_IDLE_TIMEOUT_SECONDS=600
 
 # Native DAVE audio backend (enabled by default; set false only for troubleshooting)
 EDA_DAVE=true

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ TODO
 .desloppify/
 .pi/
 
+.env.local

--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ All available keys live in `.env.example`. Configure the ones that match your se
 | `SECRET_KEY_BASE_FILE` | optional | Path to file containing signing/encryption secret (e.g. for docker secrets). Preferred for security. |
 | `PHX_HOST` | ✔ | Hostname the app advertises (`localhost` for local runs). |
 | `SCHEME` | ✔ | `http` locally, `https` in production. |
-| `AUTO_JOIN` | optional | Set to `true` to let the bot auto-join voice channels. |
+| `AUTO_JOIN` | optional | Voice join mode. `play` (default) — bot joins when you play a sound. `presence` — bot follows users into channels. `false` — manual `!join` only. |
+| `VOICE_IDLE_TIMEOUT_SECONDS` | optional | Seconds of inactivity before the bot auto-leaves. Defaults to `600` (10 min). Set to `0` to disable. In `play` mode: timer resets per sound, bot also leaves when the last user departs. In `false` mode: timer starts after the last user leaves. In `presence` mode: ignored. |
+| `BIND_IP` | optional | IP address the HTTP server binds to. Defaults to `127.0.0.1`; set to `0.0.0.0` to bind all interfaces (e.g. Docker dev). |
 
 ## Deployment
 
@@ -86,7 +88,13 @@ If you place the container behind your own reverse proxy, set `PHX_HOST` and `SC
 
 After inviting the bot to your server, join a voice channel and type `!join` to have the bot join the voice channel. Type `!leave` to have the bot leave. You can upload sounds to Soundbored and trigger them there and they will play in the voice channel.
 
-The bot is also able to auto-join and auto-leave voice channels. This is controlled by the `AUTO_JOIN` environment variable. Leave it unset (or `false`) to disable, or set it to `true` to have the bot join voice channels with members and auto-leave when the last user leaves.
+The bot manages voice channels automatically in two ways:
+
+The `AUTO_JOIN` variable controls three modes:
+
+- **`play` (default)**: the bot joins automatically when you play a sound from the web UI or API. It leaves when the last user departs or after `VOICE_IDLE_TIMEOUT_SECONDS` seconds of no playback activity (default: 600 s / 10 min).
+- **`presence`**: the bot proactively follows users into voice channels on join events, and leaves immediately when the last user departs. The idle timeout is ignored in this mode.
+- **`false`**: fully manual — use `!join` / `!leave`. If `VOICE_IDLE_TIMEOUT_SECONDS` is set, the bot leaves automatically that many seconds after the last user departs.
 
 ## API
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -54,7 +54,18 @@ if config_env() == :dev do
         nil
     end
 
-  endpoint_overrides = [url: [host: host, port: port, scheme: scheme]]
+  bind_ip =
+    case env!("BIND_IP", :string!, "127.0.0.1")
+         |> String.to_charlist()
+         |> :inet.parse_address() do
+      {:ok, ip_tuple} -> ip_tuple
+      _ -> {127, 0, 0, 1}
+    end
+
+  endpoint_overrides = [
+    url: [host: host, port: port, scheme: scheme],
+    http: [ip: bind_ip, port: port]
+  ]
 
   endpoint_overrides =
     if is_binary(secret_key_base) do

--- a/docs/specs/voice-auto-join-idle-leave.md
+++ b/docs/specs/voice-auto-join-idle-leave.md
@@ -1,0 +1,190 @@
+# Spec: Voice Channel Auto-Join on Playback & Idle Auto-Leave
+
+**Status:** Implemented  
+**Date:** 2026-04-28  
+**Author:** Justin Hart
+
+---
+
+## Summary
+
+Two related quality-of-life improvements to bot voice channel management:
+
+1. **Auto-join on play**: when a user triggers sound playback from the web UI or API and the bot is not in any voice channel, the bot automatically joins the user's current Discord voice channel before playing.
+2. **Idle auto-leave**: after no sounds have been played for a configurable period (default: 10 minutes), the bot automatically leaves the voice channel. This supplements the existing "leave when last person departs" behavior.
+
+---
+
+## Motivation
+
+Previously, users had to manually type `!join` in Discord before playing sounds from the web UI. This broke the flow: open the soundboard tab, click a sound, nothing happens, switch to Discord, type `!join`, switch back, click again. The bot also had no way to clean up a lingering voice session after everyone drifted away from a channel.
+
+These two features together make the bot feel self-managing: it follows you in and cleans up after itself.
+
+---
+
+## User-Facing Behavior
+
+### Auto-Join on Play
+
+| Situation | Before | After |
+|---|---|---|
+| Bot has no voice channel, user clicks a sound | Error: "Bot is not connected to a voice channel. Use !join in Discord first." | Bot joins the user's current voice channel and plays the sound |
+| User is not in any voice channel | Error | Same error (no channel to join) |
+| Actor is `System` (join/leave sounds) | Error | Same error (no Discord identity to look up) |
+| Bot already in a channel | Plays normally | Unchanged |
+
+The auto-join is reactive and on-demand — it does **not** change the presence-based auto-follow behavior controlled by the `AUTO_JOIN` environment variable. These are orthogonal features.
+
+### Idle Auto-Leave
+
+The bot leaves the voice channel after `VOICE_IDLE_TIMEOUT_MINUTES` minutes (default: 10) of no playback activity. "Activity" is defined as a `play_sound` cast arriving at the AudioPlayer — queuing a sound resets the clock.
+
+The idle timer interacts with existing leave behaviors as follows:
+
+| Event | Result |
+|---|---|
+| `play_sound` cast received | Timer resets to full timeout |
+| Bot joins a channel (via `!join`, auto-join, or bootstrap) | Timer starts |
+| Bot leaves a channel (any reason) | Timer cancelled |
+| Last non-bot user leaves the channel | Existing "leave when alone" logic fires; timer cancelled |
+| Idle timer fires | Bot leaves immediately (same as "last person left" behavior) |
+
+---
+
+## Architecture & Design
+
+### Auto-Join Flow
+
+```
+Web UI / API → AudioPlayer.play_sound(name, %User{discord_id: ...})
+  │
+  ▼  (voice_channel is nil)
+AudioPlayer.handle_cast({:play_sound, ...}, %{voice_channel: nil})
+  │
+  ├─ extract discord_id from actor
+  │
+  ▼
+VoicePresence.find_user_voice_channel(discord_id)
+  │  searches all cached guilds via GuildCache
+  │
+  ├─ {:ok, {guild_id, channel_id}} ──► Voice.join_channel(guild_id, channel_id)
+  │                                    update state.voice_channel
+  │                                    schedule idle timer
+  │                                    proceed with playback
+  │
+  └─ :not_found ──► Notifier.error("Bot is not connected... Use !join in Discord first.")
+```
+
+The join happens directly inside the `handle_cast` body — state is updated synchronously, and playback proceeds in the same message handler. This avoids any circular-cast problem: `VoiceCommands.join_voice_channel` normally calls `AudioPlayer.set_voice_channel` as a success callback, which would deadlock if called from inside `AudioPlayer`. By calling `Voice.join_channel/2` directly and updating state ourselves, we avoid that dependency entirely.
+
+### Idle Timeout Flow
+
+```
+AudioPlayer state: idle_timeout_ref = {timer_ref, token}
+
+set_voice_channel({guild, chan}) → cancel old timer → schedule new timer
+play_sound cast              → cancel old timer → schedule new timer (reset)
+set_voice_channel(nil, nil)  → cancel timer
+{:idle_timeout, token} msg   → leave if token matches active ref, else ignore (stale)
+```
+
+The `{ref, token}` pair in `idle_timeout_ref` guards against a race condition: if `Process.cancel_timer` returns `false` (the message already fired and is in the mailbox), the stale message arrives after the new timer is scheduled. The token mismatch causes it to be silently dropped rather than triggering a double-leave.
+
+### Actor Type Change
+
+Previously, `play_sound` actors from the web layer were plain username strings (e.g. `"justin"`), and from the API layer, a map `%{display_name: username, user_id: db_id}`. Neither carried a `discord_id` usable for voice channel lookup.
+
+Both callers now pass the full `%Soundboard.Accounts.User{}` struct. `PlaybackEngine` already handled this type (via `actor_display_name/1` and `actor_user_id/1` pattern matches), so no downstream changes were needed. The new `actor_discord_id/1` private function in `AudioPlayer` extracts the Discord ID for auto-join, and falls back to `:not_found` for strings and maps without `discord_id`.
+
+### Leave Behavior on Idle Timeout
+
+Two approaches were considered:
+
+**A — Leave immediately** (chosen): consistent with the existing "last person left" behavior. The idle timer only fires after 10+ idle minutes, so interrupting in-progress audio is essentially impossible in practice: `reset_idle_timeout` is called on every `play_sound` cast, so any active use resets the clock.
+
+**B — Extend once if playback is in progress**: check `state.current_playback` and reschedule if non-nil. Adds a second code path, a state machine edge, and the risk of indefinite extension if sounds keep queuing just before expiry.
+
+Approach A was chosen for simplicity and behavioral consistency.
+
+### Direct `Voice.leave_channel` vs `VoiceCommands.leave_voice_channel`
+
+`VoiceCommands.leave_voice_channel` would introduce a circular module dependency:
+- `VoiceCommands` already calls `AudioPlayer.set_voice_channel` (compile-time dep)
+- `AudioPlayer` calling `VoiceCommands` would close the cycle
+
+Instead, `AudioPlayer` calls `Voice.leave_channel/1` directly and updates its own state (clearing `voice_channel`, cancelling the queue). This is consistent with how `VoiceSession.maintain_connection` already calls `Voice.leave_channel` directly.
+
+---
+
+## New Module: `VoicePresence.find_user_voice_channel/1`
+
+```elixir
+@spec find_user_voice_channel(String.t()) ::
+        {:ok, {guild_id :: String.t(), channel_id :: String.t()}} | :not_found
+```
+
+Iterates over all guilds in the EDA guild cache and returns the first voice state matching the given Discord user ID. Returns `:not_found` if the user is not in any voice channel or the cache is unavailable.
+
+---
+
+## New Module: `IdleTimeoutPolicy`
+
+```
+lib/soundboard/discord/handler/idle_timeout_policy.ex
+```
+
+Reads the `VOICE_IDLE_TIMEOUT_MINUTES` environment variable. Returns the timeout in milliseconds. Follows the same shape as `AutoJoinPolicy`.
+
+---
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `VOICE_IDLE_TIMEOUT_MINUTES` | `10` | Minutes of inactivity before the bot leaves a voice channel. Set to a higher value (e.g. `60`) if you want the bot to stay around longer. |
+| `AUTO_JOIN` | `false` | **Existing, unchanged.** Controls whether the bot proactively follows users into channels on voice state updates. Orthogonal to the on-play auto-join added here. |
+
+---
+
+## Database Changes
+
+**None.**
+
+---
+
+## File Inventory
+
+| File | Action |
+|---|---|
+| `lib/soundboard/discord/handler/idle_timeout_policy.ex` | **New** — `VOICE_IDLE_TIMEOUT_MINUTES` config reader |
+| `lib/soundboard/discord/handler/voice_presence.ex` | **Modify** — add `find_user_voice_channel/1` |
+| `lib/soundboard/audio_player.ex` | **Modify** — auto-join logic, idle timeout lifecycle, actor type |
+| `lib/soundboard_web/live/support/sound_playback.ex` | **Modify** — pass `%User{}` struct instead of username string |
+| `lib/soundboard_web/controllers/api/sound_controller.ex` | **Modify** — pass `%User{}` struct instead of display-name map |
+| `test/soundboard/discord/handler/idle_timeout_policy_test.exs` | **New** |
+| `test/soundboard/discord/handler/voice_presence_test.exs` | **New** — covers `find_user_voice_channel/1` |
+| `test/soundboard_web/audio_player_test.exs` | **Modify** — idle timeout and auto-join tests added |
+| `test/soundboard_web/plugs/api_auth_db_token_test.exs` | **Modify** — actor assertion updated |
+| `test/soundboard_web/controllers/api/sound_controller_test.exs` | **Modify** — actor assertion updated |
+| `test/soundboard_web/live/favorites_live_test.exs` | **Modify** — actor assertion updated |
+
+---
+
+## Testing Strategy
+
+| Layer | What is tested |
+|---|---|
+| `IdleTimeoutPolicy` | Default (no env var) → 600,000 ms. Custom value. Whitespace trimming. |
+| `VoicePresence.find_user_voice_channel` | User found in a guild. User not found. User in guild but no channel. Multi-guild search. Cache unavailable. |
+| `AudioPlayer` — idle timeout | Timer scheduled on `set_voice_channel`. Timer cancelled on `set_voice_channel(nil, nil)`. Timer reset on `play_sound`. Timer fires → leave called, state cleared. Stale token ignored. |
+| `AudioPlayer` — auto-join | User with `discord_id` in a voice channel → join called, `voice_channel` set, idle timer started. User not in any channel → error, no join. Actor without `discord_id` (e.g. `"System"`) → no lookup attempted. |
+
+---
+
+## Out of Scope
+
+- **Auto-join for `!play` Discord commands**: the `!play` command handler already requires `!join` first; that flow was not changed.
+- **Per-guild or per-channel idle timeout**: the timeout is global. Future work could make it configurable per guild via DB settings.
+- **Idle timeout reset on playback *finish*** (as opposed to *start*): the timer resets when a sound is cast, not when it finishes playing. This means the clock starts as soon as playback is requested, not after the sound ends. For typical usage (sounds are 1–30 seconds) this makes no practical difference.
+- **Notifying users before leaving**: the bot does not send a Discord message warning that it is about to leave due to inactivity.

--- a/docs/specs/voice-auto-join-idle-leave.md
+++ b/docs/specs/voice-auto-join-idle-leave.md
@@ -1,17 +1,18 @@
 # Spec: Voice Channel Auto-Join on Playback & Idle Auto-Leave
 
 **Status:** Implemented  
-**Date:** 2026-04-28  
+**Date:** 2026-04-29  
 **Author:** Justin Hart
 
 ---
 
 ## Summary
 
-Two related quality-of-life improvements to bot voice channel management:
+Three related quality-of-life improvements to bot voice channel management, unified under a single `AUTO_JOIN` mode enum:
 
-1. **Auto-join on play**: when a user triggers sound playback from the web UI or API and the bot is not in any voice channel, the bot automatically joins the user's current Discord voice channel before playing.
-2. **Idle auto-leave**: after no sounds have been played for a configurable period (default: 10 minutes), the bot automatically leaves the voice channel. This supplements the existing "leave when last person departs" behavior.
+1. **Auto-join on play** (`play` mode): when a user triggers sound playback from the web UI or API and the bot is not in any voice channel, the bot automatically joins the user's current Discord voice channel before playing.
+2. **Idle auto-leave**: after a configurable period of inactivity (default: 600 seconds), the bot leaves the voice channel. Behavior varies by mode.
+3. **`AUTO_JOIN` mode enum**: replaces the old boolean flag with a three-value enum (`play`, `presence`, `false`) that unifies join and leave behavior into one setting.
 
 ---
 
@@ -19,47 +20,64 @@ Two related quality-of-life improvements to bot voice channel management:
 
 Previously, users had to manually type `!join` in Discord before playing sounds from the web UI. This broke the flow: open the soundboard tab, click a sound, nothing happens, switch to Discord, type `!join`, switch back, click again. The bot also had no way to clean up a lingering voice session after everyone drifted away from a channel.
 
-These two features together make the bot feel self-managing: it follows you in and cleans up after itself.
+The original implementation added auto-join on play and a global idle timeout. A follow-up redesign replaced the boolean `AUTO_JOIN` flag with a proper mode enum, aligning join behavior, leave behavior, and idle timeout semantics into a coherent model.
 
 ---
 
 ## User-Facing Behavior
 
-### Auto-Join on Play
+### `AUTO_JOIN` Modes
 
-| Situation | Before | After |
+| Mode | How bot joins | How bot leaves |
 |---|---|---|
-| Bot has no voice channel, user clicks a sound | Error: "Bot is not connected to a voice channel. Use !join in Discord first." | Bot joins the user's current voice channel and plays the sound |
-| User is not in any voice channel | Error | Same error (no channel to join) |
-| Actor is `System` (join/leave sounds) | Error | Same error (no Discord identity to look up) |
-| Bot already in a channel | Plays normally | Unchanged |
+| `play` (default) | Joins when a sound is played from the web UI or API | Leaves when last user departs **or** after `VOICE_IDLE_TIMEOUT_SECONDS` of no audio (whichever first). If timeout ≤ 0, only leaves when last user departs. |
+| `presence` | Follows users into channels on voice-state updates (existing behavior) | Leaves immediately when last user departs. Idle timeout is **ignored**. |
+| `false` | Manual `!join` only | If timeout > 0: leaves after `VOICE_IDLE_TIMEOUT_SECONDS` of being alone (timer starts when last user departs, cancels if a user rejoins). If timeout ≤ 0: never auto-leaves. |
 
-The auto-join is reactive and on-demand — it does **not** change the presence-based auto-follow behavior controlled by the `AUTO_JOIN` environment variable. These are orthogonal features.
+The old `AUTO_JOIN=true` maps to `presence`; `AUTO_JOIN=false` (explicit) maps to `false`; unset now defaults to `play`.
 
-### Idle Auto-Leave
+### Auto-Join on Play (in `play` mode)
 
-The bot leaves the voice channel after `VOICE_IDLE_TIMEOUT_MINUTES` minutes (default: 10) of no playback activity. "Activity" is defined as a `play_sound` cast arriving at the AudioPlayer — queuing a sound resets the clock.
-
-The idle timer interacts with existing leave behaviors as follows:
-
-| Event | Result |
+| Situation | Behavior |
 |---|---|
-| `play_sound` cast received | Timer resets to full timeout |
-| Bot joins a channel (via `!join`, auto-join, or bootstrap) | Timer starts |
-| Bot leaves a channel (any reason) | Timer cancelled |
-| Last non-bot user leaves the channel | Existing "leave when alone" logic fires; timer cancelled |
-| Idle timer fires | Bot leaves immediately (same as "last person left" behavior) |
+| Bot has no voice channel, user clicks a sound | Bot joins the user's current voice channel and plays the sound |
+| User is not in any voice channel | Error: "Bot is not connected to a voice channel. Use !join in Discord first." |
+| Actor is `System` (join/leave sounds) | Same error (no Discord identity to look up) |
+| Bot already in a channel | Plays normally, unchanged |
+| Mode is `presence` or `false` | Error (no auto-join, must use `!join`) |
+
+### Idle Timeout Semantics by Mode
+
+| Event | `play` mode | `presence` mode | `false` mode |
+|---|---|---|---|
+| Bot joins a channel | Timer starts (if timeout > 0) | No timer | No timer |
+| `play_sound` cast | Timer resets | No effect | No effect |
+| Last user leaves | Leave immediately | Leave immediately | Start idle timer (if timeout > 0) |
+| User rejoins (bot alone) | N/A | N/A | Cancel idle timer |
+| Idle timer fires | Leave immediately | Never fires | Leave immediately |
+| Bot leaves (any reason) | Timer cancelled | N/A | Timer cancelled |
 
 ---
 
 ## Architecture & Design
 
-### Auto-Join Flow
+### `AUTO_JOIN` Enum
+
+`AutoJoinPolicy.mode/0` now returns `:presence | :play | false` (the boolean `false`, not an atom, per Elixir convention). Parsing rules:
+
+| `AUTO_JOIN` value | Mode |
+|---|---|
+| not set | `:play` |
+| `play` | `:play` |
+| `presence`, `true`, `1`, `yes` | `:presence` |
+| `false`, `0`, `no`, any other | `false` |
+
+### Auto-Join Flow (play mode only)
 
 ```
 Web UI / API → AudioPlayer.play_sound(name, %User{discord_id: ...})
   │
-  ▼  (voice_channel is nil)
+  ▼  (voice_channel is nil AND mode == :play)
 AudioPlayer.handle_cast({:play_sound, ...}, %{voice_channel: nil})
   │
   ├─ extract discord_id from actor
@@ -70,7 +88,7 @@ VoicePresence.find_user_voice_channel(discord_id)
   │
   ├─ {:ok, {guild_id, channel_id}} ──► Voice.join_channel(guild_id, channel_id)
   │                                    update state.voice_channel
-  │                                    schedule idle timer
+  │                                    schedule idle timer (if timeout > 0)
   │                                    proceed with playback
   │
   └─ :not_found ──► Notifier.error("Bot is not connected... Use !join in Discord first.")
@@ -78,34 +96,51 @@ VoicePresence.find_user_voice_channel(discord_id)
 
 The join happens directly inside the `handle_cast` body — state is updated synchronously, and playback proceeds in the same message handler. This avoids any circular-cast problem: `VoiceCommands.join_voice_channel` normally calls `AudioPlayer.set_voice_channel` as a success callback, which would deadlock if called from inside `AudioPlayer`. By calling `Voice.join_channel/2` directly and updating state ourselves, we avoid that dependency entirely.
 
-### Idle Timeout Flow
+### Last-User-Left Routing
+
+`VoiceRuntime.handle_disconnect` now runs for **all** modes (previously short-circuited for `:disabled`). When the bot is confirmed alone, `bot_alone_action/1` dispatches by mode:
 
 ```
-AudioPlayer state: idle_timeout_ref = {timer_ref, token}
-
-set_voice_channel({guild, chan}) → cancel old timer → schedule new timer
-play_sound cast              → cancel old timer → schedule new timer (reset)
-set_voice_channel(nil, nil)  → cancel timer
-{:idle_timeout, token} msg   → leave if token matches active ref, else ignore (stale)
+bot_alone_action(guild_id)
+  :presence  ──► VoiceCommands.leave_voice_channel(guild_id)  (existing path)
+  :play      ──► AudioPlayer.last_user_left(guild_id)         (leave immediately)
+  false      ──► AudioPlayer.last_user_left(guild_id)         (start idle timer)
 ```
 
-The `{ref, token}` pair in `idle_timeout_ref` guards against a race condition: if `Process.cancel_timer` returns `false` (the message already fired and is in the mailbox), the stale message arrives after the new timer is scheduled. The token mismatch causes it to be silently dropped rather than triggering a double-leave.
+`AudioPlayer.last_user_left/1` is the new single entry point for non-presence leave events. It:
+- `:play` / `:presence`: calls `Voice.leave_channel` directly, clears state.
+- `false`: calls `reset_idle_timeout` — starts the idle timer if `VOICE_IDLE_TIMEOUT_SECONDS > 0`, otherwise no-ops (bot stays indefinitely).
 
-### Actor Type Change
+### User-Rejoin Cancel (false mode only)
 
-Previously, `play_sound` actors from the web layer were plain username strings (e.g. `"justin"`), and from the API layer, a map `%{display_name: username, user_id: db_id}`. Neither carried a `discord_id` usable for voice channel lookup.
+`VoiceRuntime.handle_connect` gains a `false`-mode clause: when a non-bot user joins the bot's current channel, it calls `AudioPlayer.user_joined_channel/1`, which cancels the idle timer. This prevents the bot from leaving when a user briefly steps out and returns.
 
-Both callers now pass the full `%Soundboard.Accounts.User{}` struct. `PlaybackEngine` already handled this type (via `actor_display_name/1` and `actor_user_id/1` pattern matches), so no downstream changes were needed. The new `actor_discord_id/1` private function in `AudioPlayer` extracts the Discord ID for auto-join, and falls back to `:not_found` for strings and maps without `discord_id`.
+### Idle Timeout State Machine
 
-### Leave Behavior on Idle Timeout
+```
+AudioPlayer state: idle_timeout_ref = {timer_ref, token} | nil
 
-Two approaches were considered:
+play mode:
+  set_voice_channel({guild, chan}) → cancel old timer → schedule new timer
+  play_sound cast                 → cancel old timer → schedule new timer (reset)
+  set_voice_channel(nil, nil)     → cancel timer
+  last_user_left                  → leave immediately, cancel timer
+  {:idle_timeout, token}          → leave if token matches, else ignore (stale)
 
-**A — Leave immediately** (chosen): consistent with the existing "last person left" behavior. The idle timer only fires after 10+ idle minutes, so interrupting in-progress audio is essentially impossible in practice: `reset_idle_timeout` is called on every `play_sound` cast, so any active use resets the clock.
+false mode:
+  last_user_left                  → schedule timer (if timeout > 0)
+  user_joined_channel             → cancel timer
+  {:idle_timeout, token}          → leave if token matches, else ignore (stale)
 
-**B — Extend once if playback is in progress**: check `state.current_playback` and reschedule if non-nil. Adds a second code path, a state machine edge, and the risk of indefinite extension if sounds keep queuing just before expiry.
+presence mode:
+  (no timer ever scheduled)
+```
 
-Approach A was chosen for simplicity and behavioral consistency.
+The `{ref, token}` pair guards against a race condition: if `Process.cancel_timer` returns `false` (the message already fired and is in the mailbox), the stale message arrives after a new timer is scheduled. The token mismatch causes it to be silently dropped rather than triggering a spurious leave.
+
+### `IdleTimeoutPolicy` — Disabled State
+
+`timeout_ms/0` now returns `nil` when `VOICE_IDLE_TIMEOUT_SECONDS <= 0` (previously always returned a positive integer). Callers treat `nil` as "disabled" and skip scheduling. This is how `false` mode achieves "never auto-leave" behavior.
 
 ### Direct `Voice.leave_channel` vs `VoiceCommands.leave_voice_channel`
 
@@ -113,11 +148,17 @@ Approach A was chosen for simplicity and behavioral consistency.
 - `VoiceCommands` already calls `AudioPlayer.set_voice_channel` (compile-time dep)
 - `AudioPlayer` calling `VoiceCommands` would close the cycle
 
-Instead, `AudioPlayer` calls `Voice.leave_channel/1` directly and updates its own state (clearing `voice_channel`, cancelling the queue). This is consistent with how `VoiceSession.maintain_connection` already calls `Voice.leave_channel` directly.
+`AudioPlayer` calls `Voice.leave_channel/1` directly and updates its own state. This is consistent with how `VoiceSession.maintain_connection` already calls `Voice.leave_channel` directly. The `:presence` path continues to use `VoiceCommands` via `VoiceRuntime` (no circular dep there).
+
+### Actor Type Change
+
+Previously, `play_sound` actors from the web layer were plain username strings (e.g. `"justin"`), and from the API layer, a map `%{display_name: username, user_id: db_id}`. Neither carried a `discord_id` usable for voice channel lookup.
+
+Both callers now pass the full `%Soundboard.Accounts.User{}` struct. `PlaybackEngine` already handled this type (via `actor_display_name/1` and `actor_user_id/1` pattern matches), so no downstream changes were needed. The new `actor_discord_id/1` private function in `AudioPlayer` extracts the Discord ID for auto-join, and falls back to `nil` for strings and maps without `discord_id`.
 
 ---
 
-## New Module: `VoicePresence.find_user_voice_channel/1`
+## New Function: `VoicePresence.find_user_voice_channel/1`
 
 ```elixir
 @spec find_user_voice_channel(String.t()) ::
@@ -134,7 +175,7 @@ Iterates over all guilds in the EDA guild cache and returns the first voice stat
 lib/soundboard/discord/handler/idle_timeout_policy.ex
 ```
 
-Reads the `VOICE_IDLE_TIMEOUT_MINUTES` environment variable. Returns the timeout in milliseconds. Follows the same shape as `AutoJoinPolicy`.
+Reads the `VOICE_IDLE_TIMEOUT_SECONDS` environment variable. Returns the timeout in milliseconds, or `nil` if the value is ≤ 0.
 
 ---
 
@@ -142,8 +183,8 @@ Reads the `VOICE_IDLE_TIMEOUT_MINUTES` environment variable. Returns the timeout
 
 | Variable | Default | Description |
 |---|---|---|
-| `VOICE_IDLE_TIMEOUT_MINUTES` | `10` | Minutes of inactivity before the bot leaves a voice channel. Set to a higher value (e.g. `60`) if you want the bot to stay around longer. |
-| `AUTO_JOIN` | `false` | **Existing, unchanged.** Controls whether the bot proactively follows users into channels on voice state updates. Orthogonal to the on-play auto-join added here. |
+| `AUTO_JOIN` | `play` | Join/leave mode. `play` — join on sound playback, leave on idle or last user. `presence` — follow users in, leave when alone. `false` — manual only, leave after idle timeout once alone. |
+| `VOICE_IDLE_TIMEOUT_SECONDS` | `600` | Seconds of inactivity before auto-leave. Set to `0` to disable. In `play` mode: resets on each sound played. In `false` mode: starts when last user leaves, cancels if a user rejoins. In `presence` mode: ignored. |
 
 ---
 
@@ -157,14 +198,19 @@ Reads the `VOICE_IDLE_TIMEOUT_MINUTES` environment variable. Returns the timeout
 
 | File | Action |
 |---|---|
-| `lib/soundboard/discord/handler/idle_timeout_policy.ex` | **New** — `VOICE_IDLE_TIMEOUT_MINUTES` config reader |
+| `lib/soundboard/discord/handler/auto_join_policy.ex` | **Modify** — boolean → enum (`:presence`, `:play`, `false`); remove `enabled?/0` |
+| `lib/soundboard/discord/handler/idle_timeout_policy.ex` | **New** — `VOICE_IDLE_TIMEOUT_SECONDS` config reader; returns `nil` when disabled |
 | `lib/soundboard/discord/handler/voice_presence.ex` | **Modify** — add `find_user_voice_channel/1` |
-| `lib/soundboard/audio_player.ex` | **Modify** — auto-join logic, idle timeout lifecycle, actor type |
+| `lib/soundboard/discord/handler/voice_runtime.ex` | **Modify** — mode-aware connect/disconnect routing; `bot_alone_action/1`; `handle_user_rejoin_cancel/1` |
+| `lib/soundboard/audio_player.ex` | **Modify** — mode-gated auto-join, idle timer, and last-user-left; new `last_user_left/1` and `user_joined_channel/1` public API |
 | `lib/soundboard_web/live/support/sound_playback.ex` | **Modify** — pass `%User{}` struct instead of username string |
 | `lib/soundboard_web/controllers/api/sound_controller.ex` | **Modify** — pass `%User{}` struct instead of display-name map |
-| `test/soundboard/discord/handler/idle_timeout_policy_test.exs` | **New** |
+| `test/soundboard/discord/handler/auto_join_policy_test.exs` | **Rewrite** — enum mode tests; removed `enabled?/0` tests |
+| `test/soundboard/discord/handler/idle_timeout_policy_test.exs` | **New** — covers default, custom value, whitespace, disabled (0 and negative) |
 | `test/soundboard/discord/handler/voice_presence_test.exs` | **New** — covers `find_user_voice_channel/1` |
-| `test/soundboard_web/audio_player_test.exs` | **Modify** — idle timeout and auto-join tests added |
+| `test/soundboard/discord/handler/voice_runtime_test.exs` | **Modify** — updated mocks to `:presence`; new tests for `play`/`false` mode routing and user-rejoin cancel |
+| `test/soundboard_web/audio_player_test.exs` | **Modify** — mode-gated idle timeout and auto-join tests; new `last_user_left` and `user_joined_channel` tests |
+| `test/soundboard_web/discord_handler_test.exs` | **Modify** — presence-mode mock; updated leave-sequence assertion |
 | `test/soundboard_web/plugs/api_auth_db_token_test.exs` | **Modify** — actor assertion updated |
 | `test/soundboard_web/controllers/api/sound_controller_test.exs` | **Modify** — actor assertion updated |
 | `test/soundboard_web/live/favorites_live_test.exs` | **Modify** — actor assertion updated |
@@ -175,10 +221,14 @@ Reads the `VOICE_IDLE_TIMEOUT_MINUTES` environment variable. Returns the timeout
 
 | Layer | What is tested |
 |---|---|
-| `IdleTimeoutPolicy` | Default (no env var) → 600,000 ms. Custom value. Whitespace trimming. |
+| `AutoJoinPolicy` | Test env → `:play`. Default (no env var) → `:play`. `play` → `:play`. `presence`/truthy → `:presence`. `false`/falsy/unknown → `false`. |
+| `IdleTimeoutPolicy` | Default → 600,000 ms. Custom value. Whitespace trimming. `0` → `nil`. Negative → `nil`. |
 | `VoicePresence.find_user_voice_channel` | User found in a guild. User not found. User in guild but no channel. Multi-guild search. Cache unavailable. |
-| `AudioPlayer` — idle timeout | Timer scheduled on `set_voice_channel`. Timer cancelled on `set_voice_channel(nil, nil)`. Timer reset on `play_sound`. Timer fires → leave called, state cleared. Stale token ignored. |
-| `AudioPlayer` — auto-join | User with `discord_id` in a voice channel → join called, `voice_channel` set, idle timer started. User not in any channel → error, no join. Actor without `discord_id` (e.g. `"System"`) → no lookup attempted. |
+| `VoiceRuntime` | `handle_disconnect` notifies `AudioPlayer.last_user_left` in `:play` and `false` modes. `handle_connect` cancels idle timer via `AudioPlayer.user_joined_channel` in `false` mode. Bootstrap skips guild scan in `:play` mode. |
+| `AudioPlayer` — idle timeout | Timer scheduled on `set_voice_channel` in `:play` mode only. Not scheduled in `:presence` or `false` mode. Timer cancelled on clear. Timer reset on `play_sound` in `:play` mode only (not reset in `:presence`). Timer fires → leave called, state cleared. Stale token ignored. |
+| `AudioPlayer` — `last_user_left` | Leaves immediately in `:play` and `:presence` modes. Starts idle timer in `false` mode with timeout. No-ops in `false` mode with timeout disabled. Ignores call when bot is not in a channel. |
+| `AudioPlayer` — `user_joined_channel` | Cancels idle timer. |
+| `AudioPlayer` — auto-join | User with `discord_id` in a voice channel → join called, `voice_channel` set, idle timer started (`:play` mode). User not in any channel → error, no join. Actor without `discord_id` → no lookup attempted. Auto-join skipped in `false` mode. |
 
 ---
 
@@ -188,3 +238,4 @@ Reads the `VOICE_IDLE_TIMEOUT_MINUTES` environment variable. Returns the timeout
 - **Per-guild or per-channel idle timeout**: the timeout is global. Future work could make it configurable per guild via DB settings.
 - **Idle timeout reset on playback *finish*** (as opposed to *start*): the timer resets when a sound is cast, not when it finishes playing. This means the clock starts as soon as playback is requested, not after the sound ends. For typical usage (sounds are 1–30 seconds) this makes no practical difference.
 - **Notifying users before leaving**: the bot does not send a Discord message warning that it is about to leave due to inactivity.
+- **`false` mode last-user-leave recheck delay**: the 1.5-second recheck-alone logic in `VoiceRuntime` applies for all modes, including `false`. The idle timer in `false` mode does not start until the recheck confirms the bot is alone.

--- a/lib/soundboard/audio_player.ex
+++ b/lib/soundboard/audio_player.ex
@@ -5,7 +5,11 @@ defmodule Soundboard.AudioPlayer do
 
   use GenServer
 
+  require Logger
+
+  alias Soundboard.Accounts.User
   alias Soundboard.AudioPlayer.{Notifier, PlaybackQueue, SoundLibrary, VoiceSession}
+  alias Soundboard.Discord.Handler.{IdleTimeoutPolicy, VoicePresence}
   alias Soundboard.Discord.Voice
 
   @interrupt_watchdog_ms 35
@@ -22,7 +26,8 @@ defmodule Soundboard.AudioPlayer do
       :pending_request,
       :interrupting,
       :interrupt_watchdog_ref,
-      :interrupt_watchdog_attempt
+      :interrupt_watchdog_attempt,
+      :idle_timeout_ref
     ]
 
     @type t :: %__MODULE__{
@@ -31,7 +36,8 @@ defmodule Soundboard.AudioPlayer do
             pending_request: map() | nil,
             interrupting: boolean() | nil,
             interrupt_watchdog_ref: reference() | nil,
-            interrupt_watchdog_attempt: non_neg_integer() | nil
+            interrupt_watchdog_attempt: non_neg_integer() | nil,
+            idle_timeout_ref: {reference(), reference()} | nil
           }
   end
 
@@ -80,7 +86,8 @@ defmodule Soundboard.AudioPlayer do
          pending_request: nil,
          interrupting: false,
          interrupt_watchdog_ref: nil,
-         interrupt_watchdog_attempt: 0
+         interrupt_watchdog_attempt: 0,
+         idle_timeout_ref: nil
      }}
   end
 
@@ -91,10 +98,14 @@ defmodule Soundboard.AudioPlayer do
         nil ->
           state
           |> PlaybackQueue.clear_all()
+          |> cancel_idle_timeout()
           |> Map.put(:voice_channel, nil)
 
         voice_channel ->
-          %{state | voice_channel: voice_channel}
+          state
+          |> cancel_idle_timeout()
+          |> Map.put(:voice_channel, voice_channel)
+          |> schedule_idle_timeout()
       end
 
     {:noreply, next_state}
@@ -116,26 +127,48 @@ defmodule Soundboard.AudioPlayer do
     {:noreply, PlaybackQueue.handle_playback_finished(state, guild_id)}
   end
 
-  def handle_cast({:play_sound, _sound_name, _actor}, %{voice_channel: nil} = state) do
-    Notifier.error("Bot is not connected to a voice channel. Use !join in Discord first.")
-    {:noreply, state}
-  end
+  def handle_cast({:play_sound, sound_name, actor}, %{voice_channel: nil} = state) do
+    case try_auto_join(actor) do
+      {:ok, {guild_id, channel_id}} ->
+        new_state =
+          state
+          |> Map.put(:voice_channel, {guild_id, channel_id})
+          |> schedule_idle_timeout()
 
-  def handle_cast({:play_sound, sound_name, actor}, %{voice_channel: voice_channel} = state) do
-    case PlaybackQueue.build_request(voice_channel, sound_name, actor) do
-      {:ok, request} ->
-        {:noreply, PlaybackQueue.enqueue(state, request, @interrupt_watchdog_ms)}
+        do_play_sound(sound_name, actor, new_state)
 
-      {:error, reason} ->
-        Notifier.error(reason)
+      :not_found ->
+        Notifier.error("Bot is not connected to a voice channel. Use !join in Discord first.")
         {:noreply, state}
     end
+  end
+
+  def handle_cast({:play_sound, sound_name, actor}, state) do
+    do_play_sound(sound_name, actor, state)
   end
 
   @impl true
   def handle_call(:get_voice_channel, _from, state) do
     {:reply, state.voice_channel, state}
   end
+
+  @impl true
+  def handle_info(
+        {:idle_timeout, token},
+        %{idle_timeout_ref: {_ref, token}, voice_channel: {guild_id, _}} = state
+      ) do
+    Logger.info("Voice idle timeout in guild #{guild_id}; leaving channel")
+    safely_leave(guild_id)
+
+    new_state =
+      %{state | idle_timeout_ref: nil}
+      |> PlaybackQueue.clear_all()
+      |> Map.put(:voice_channel, nil)
+
+    {:noreply, new_state}
+  end
+
+  def handle_info({:idle_timeout, _stale_token}, state), do: {:noreply, state}
 
   @impl true
   def handle_info(:check_voice_connection, state) do
@@ -171,6 +204,72 @@ defmodule Soundboard.AudioPlayer do
 
   @impl true
   def handle_info(_, state), do: {:noreply, state}
+
+  defp do_play_sound(sound_name, actor, %{voice_channel: voice_channel} = state) do
+    case PlaybackQueue.build_request(voice_channel, sound_name, actor) do
+      {:ok, request} ->
+        {:noreply,
+         state |> reset_idle_timeout() |> PlaybackQueue.enqueue(request, @interrupt_watchdog_ms)}
+
+      {:error, reason} ->
+        Notifier.error(reason)
+        {:noreply, state}
+    end
+  end
+
+  defp try_auto_join(actor) do
+    case actor_discord_id(actor) do
+      nil -> :not_found
+      discord_id -> find_and_join_voice(discord_id)
+    end
+  end
+
+  defp find_and_join_voice(discord_id) do
+    case VoicePresence.find_user_voice_channel(discord_id) do
+      {:ok, {guild_id, channel_id}} ->
+        Logger.info(
+          "Auto-joining channel #{channel_id} in guild #{guild_id} for user #{discord_id}"
+        )
+
+        Voice.join_channel(guild_id, channel_id)
+        {:ok, {guild_id, channel_id}}
+
+      :not_found ->
+        Logger.info("User #{discord_id} not in a voice channel; skipping auto-join")
+        :not_found
+    end
+  rescue
+    error ->
+      Logger.warning("Auto-join failed: #{inspect(error)}")
+      :not_found
+  end
+
+  defp safely_leave(guild_id) do
+    Voice.leave_channel(guild_id)
+  rescue
+    error -> Logger.warning("Voice leave failed during idle timeout: #{inspect(error)}")
+  end
+
+  defp actor_discord_id(%User{discord_id: id}) when is_binary(id) and id != "", do: id
+  defp actor_discord_id(%{discord_id: id}) when is_binary(id) and id != "", do: id
+  defp actor_discord_id(_), do: nil
+
+  defp schedule_idle_timeout(state) do
+    token = make_ref()
+    ref = Process.send_after(self(), {:idle_timeout, token}, IdleTimeoutPolicy.timeout_ms())
+    %{state | idle_timeout_ref: {ref, token}}
+  end
+
+  defp cancel_idle_timeout(%{idle_timeout_ref: nil} = state), do: state
+
+  defp cancel_idle_timeout(%{idle_timeout_ref: {ref, _token}} = state) do
+    Process.cancel_timer(ref)
+    %{state | idle_timeout_ref: nil}
+  end
+
+  defp reset_idle_timeout(state) do
+    state |> cancel_idle_timeout() |> schedule_idle_timeout()
+  end
 
   defp schedule_voice_check do
     Process.send_after(self(), :check_voice_connection, 30_000)

--- a/lib/soundboard/audio_player.ex
+++ b/lib/soundboard/audio_player.ex
@@ -9,7 +9,7 @@ defmodule Soundboard.AudioPlayer do
 
   alias Soundboard.Accounts.User
   alias Soundboard.AudioPlayer.{Notifier, PlaybackQueue, SoundLibrary, VoiceSession}
-  alias Soundboard.Discord.Handler.{IdleTimeoutPolicy, VoicePresence}
+  alias Soundboard.Discord.Handler.{AutoJoinPolicy, IdleTimeoutPolicy, VoicePresence}
   alias Soundboard.Discord.Voice
 
   @interrupt_watchdog_ms 35
@@ -57,6 +57,14 @@ defmodule Soundboard.AudioPlayer do
     GenServer.cast(__MODULE__, {:set_voice_channel, guild_id, channel_id})
   end
 
+  def last_user_left(guild_id) do
+    GenServer.cast(__MODULE__, {:last_user_left, guild_id})
+  end
+
+  def user_joined_channel(guild_id) do
+    GenServer.cast(__MODULE__, {:user_joined_channel, guild_id})
+  end
+
   def playback_finished(guild_id) do
     GenServer.cast(__MODULE__, {:playback_finished, guild_id})
   end
@@ -102,10 +110,12 @@ defmodule Soundboard.AudioPlayer do
           |> Map.put(:voice_channel, nil)
 
         voice_channel ->
-          state
-          |> cancel_idle_timeout()
-          |> Map.put(:voice_channel, voice_channel)
-          |> schedule_idle_timeout()
+          new_state =
+            state
+            |> cancel_idle_timeout()
+            |> Map.put(:voice_channel, voice_channel)
+
+          if AutoJoinPolicy.mode() == :play, do: schedule_idle_timeout(new_state), else: new_state
       end
 
     {:noreply, next_state}
@@ -128,23 +138,54 @@ defmodule Soundboard.AudioPlayer do
   end
 
   def handle_cast({:play_sound, sound_name, actor}, %{voice_channel: nil} = state) do
-    case try_auto_join(actor) do
-      {:ok, {guild_id, channel_id}} ->
-        new_state =
-          state
-          |> Map.put(:voice_channel, {guild_id, channel_id})
-          |> schedule_idle_timeout()
+    if AutoJoinPolicy.mode() == :play do
+      case try_auto_join(actor) do
+        {:ok, {guild_id, channel_id}} ->
+          new_state =
+            state
+            |> Map.put(:voice_channel, {guild_id, channel_id})
+            |> schedule_idle_timeout()
 
-        do_play_sound(sound_name, actor, new_state)
+          do_play_sound(sound_name, actor, new_state)
 
-      :not_found ->
-        Notifier.error("Bot is not connected to a voice channel. Use !join in Discord first.")
-        {:noreply, state}
+        :not_found ->
+          Notifier.error("Bot is not connected to a voice channel. Use !join in Discord first.")
+          {:noreply, state}
+      end
+    else
+      Notifier.error("Bot is not connected to a voice channel. Use !join in Discord first.")
+      {:noreply, state}
     end
   end
 
   def handle_cast({:play_sound, sound_name, actor}, state) do
     do_play_sound(sound_name, actor, state)
+  end
+
+  def handle_cast({:last_user_left, guild_id}, %{voice_channel: {guild_id, _}} = state) do
+    case AutoJoinPolicy.mode() do
+      mode when mode in [:presence, :play] ->
+        Logger.info("Last user left (#{mode} mode); leaving guild #{guild_id}")
+        safely_leave(guild_id)
+
+        new_state =
+          state
+          |> cancel_idle_timeout()
+          |> PlaybackQueue.clear_all()
+          |> Map.put(:voice_channel, nil)
+
+        {:noreply, new_state}
+
+      false ->
+        Logger.info("Last user left (false mode); starting idle timer")
+        {:noreply, reset_idle_timeout(state)}
+    end
+  end
+
+  def handle_cast({:last_user_left, _guild_id}, state), do: {:noreply, state}
+
+  def handle_cast({:user_joined_channel, _guild_id}, state) do
+    {:noreply, cancel_idle_timeout(state)}
   end
 
   @impl true
@@ -208,8 +249,10 @@ defmodule Soundboard.AudioPlayer do
   defp do_play_sound(sound_name, actor, %{voice_channel: voice_channel} = state) do
     case PlaybackQueue.build_request(voice_channel, sound_name, actor) do
       {:ok, request} ->
-        {:noreply,
-         state |> reset_idle_timeout() |> PlaybackQueue.enqueue(request, @interrupt_watchdog_ms)}
+        new_state =
+          if AutoJoinPolicy.mode() == :play, do: reset_idle_timeout(state), else: state
+
+        {:noreply, PlaybackQueue.enqueue(new_state, request, @interrupt_watchdog_ms)}
 
       {:error, reason} ->
         Notifier.error(reason)
@@ -247,7 +290,7 @@ defmodule Soundboard.AudioPlayer do
   defp safely_leave(guild_id) do
     Voice.leave_channel(guild_id)
   rescue
-    error -> Logger.warning("Voice leave failed during idle timeout: #{inspect(error)}")
+    error -> Logger.warning("Voice leave failed: #{inspect(error)}")
   end
 
   defp actor_discord_id(%User{discord_id: id}) when is_binary(id) and id != "", do: id
@@ -255,9 +298,15 @@ defmodule Soundboard.AudioPlayer do
   defp actor_discord_id(_), do: nil
 
   defp schedule_idle_timeout(state) do
-    token = make_ref()
-    ref = Process.send_after(self(), {:idle_timeout, token}, IdleTimeoutPolicy.timeout_ms())
-    %{state | idle_timeout_ref: {ref, token}}
+    case IdleTimeoutPolicy.timeout_ms() do
+      nil ->
+        state
+
+      ms ->
+        token = make_ref()
+        ref = Process.send_after(self(), {:idle_timeout, token}, ms)
+        %{state | idle_timeout_ref: {ref, token}}
+    end
   end
 
   defp cancel_idle_timeout(%{idle_timeout_ref: nil} = state), do: state

--- a/lib/soundboard/discord/handler.ex
+++ b/lib/soundboard/discord/handler.ex
@@ -99,7 +99,12 @@ defmodule Soundboard.Discord.Handler do
     if VoiceRuntime.bot_user?(payload.user_id) do
       Logger.debug("Skipping join sound lookup for bot user #{payload.user_id}")
     else
-      SoundEffects.handle_join(payload.user_id, previous_state, payload.channel_id)
+      SoundEffects.handle_join(
+        payload.user_id,
+        previous_state,
+        payload.guild_id,
+        payload.channel_id
+      )
     end
 
     runtime_actions

--- a/lib/soundboard/discord/handler/auto_join_policy.ex
+++ b/lib/soundboard/discord/handler/auto_join_policy.ex
@@ -1,24 +1,23 @@
 defmodule Soundboard.Discord.Handler.AutoJoinPolicy do
   @moduledoc false
 
+  @type mode :: :presence | :play | false
+
+  @spec mode() :: mode()
   def mode do
     case Application.get_env(:soundboard, :env) do
-      :test -> :enabled
-      _ -> if enabled?(), do: :enabled, else: :disabled
+      :test -> :play
+      _ -> parse_mode(System.get_env("AUTO_JOIN"))
     end
   end
 
-  def enabled? do
-    case System.get_env("AUTO_JOIN") do
-      nil -> false
-      value -> truthy_value?(value)
-    end
-  end
+  defp parse_mode(nil), do: :play
 
-  defp truthy_value?(value) do
-    value
-    |> String.trim()
-    |> String.downcase()
-    |> then(&(&1 in ["true", "1", "yes"]))
+  defp parse_mode(value) do
+    case value |> String.trim() |> String.downcase() do
+      v when v in ["presence", "true", "1", "yes"] -> :presence
+      "play" -> :play
+      _ -> false
+    end
   end
 end

--- a/lib/soundboard/discord/handler/idle_timeout_policy.ex
+++ b/lib/soundboard/discord/handler/idle_timeout_policy.ex
@@ -1,0 +1,15 @@
+defmodule Soundboard.Discord.Handler.IdleTimeoutPolicy do
+  @moduledoc false
+
+  @default_minutes 10
+
+  def timeout_ms do
+    minutes =
+      case System.get_env("VOICE_IDLE_TIMEOUT_MINUTES") do
+        nil -> @default_minutes
+        raw -> raw |> String.trim() |> String.to_integer()
+      end
+
+    minutes * 60_000
+  end
+end

--- a/lib/soundboard/discord/handler/idle_timeout_policy.ex
+++ b/lib/soundboard/discord/handler/idle_timeout_policy.ex
@@ -1,15 +1,20 @@
 defmodule Soundboard.Discord.Handler.IdleTimeoutPolicy do
   @moduledoc false
 
-  @default_minutes 10
+  @default_seconds 600
 
+  @spec timeout_ms() :: pos_integer() | nil
   def timeout_ms do
-    minutes =
-      case System.get_env("VOICE_IDLE_TIMEOUT_MINUTES") do
-        nil -> @default_minutes
-        raw -> raw |> String.trim() |> String.to_integer()
-      end
+    case raw_seconds() do
+      n when n <= 0 -> nil
+      n -> n * 1_000
+    end
+  end
 
-    minutes * 60_000
+  defp raw_seconds do
+    case System.get_env("VOICE_IDLE_TIMEOUT_SECONDS") do
+      nil -> @default_seconds
+      raw -> raw |> String.trim() |> String.to_integer()
+    end
   end
 end

--- a/lib/soundboard/discord/handler/idle_timeout_policy.ex
+++ b/lib/soundboard/discord/handler/idle_timeout_policy.ex
@@ -1,6 +1,8 @@
 defmodule Soundboard.Discord.Handler.IdleTimeoutPolicy do
   @moduledoc false
 
+  require Logger
+
   @default_seconds 600
 
   @spec timeout_ms() :: pos_integer() | nil
@@ -13,8 +15,18 @@ defmodule Soundboard.Discord.Handler.IdleTimeoutPolicy do
 
   defp raw_seconds do
     case System.get_env("VOICE_IDLE_TIMEOUT_SECONDS") do
-      nil -> @default_seconds
-      raw -> raw |> String.trim() |> String.to_integer()
+      nil ->
+        @default_seconds
+
+      raw ->
+        case raw |> String.trim() |> Integer.parse() do
+          {n, ""} ->
+            n
+
+          _ ->
+            Logger.warning("Invalid VOICE_IDLE_TIMEOUT_SECONDS=#{inspect(raw)}; using default")
+            @default_seconds
+        end
     end
   end
 end

--- a/lib/soundboard/discord/handler/sound_effects.ex
+++ b/lib/soundboard/discord/handler/sound_effects.ex
@@ -4,21 +4,22 @@ defmodule Soundboard.Discord.Handler.SoundEffects do
   require Logger
 
   alias Soundboard.{AudioPlayer, Sounds}
+  alias Soundboard.Discord.Handler.{AutoJoinPolicy, VoiceRuntime}
 
-  def handle_join(user_id, previous_state, new_channel_id) do
+  def handle_join(user_id, previous_state, guild_id, channel_id) do
     is_join_event =
       case previous_state do
         nil -> true
         {nil, _} -> true
-        {prev_channel, _} -> prev_channel != new_channel_id
+        {prev_channel, _} -> prev_channel != channel_id
       end
 
     Logger.info(
-      "Join sound check - User: #{user_id}, Previous: #{inspect(previous_state)}, New channel: #{new_channel_id}, Is join: #{is_join_event}"
+      "Join sound check - User: #{user_id}, Previous: #{inspect(previous_state)}, New channel: #{channel_id}, Is join: #{is_join_event}"
     )
 
     if is_join_event do
-      play_join_sound(user_id)
+      play_join_sound(user_id, guild_id, channel_id)
     else
       :noop
     end
@@ -35,7 +36,7 @@ defmodule Soundboard.Discord.Handler.SoundEffects do
     end
   end
 
-  defp play_join_sound(user_id) do
+  defp play_join_sound(user_id, guild_id, channel_id) do
     join_sound = Sounds.get_user_join_sound_by_discord_id(user_id)
 
     Logger.info("Join sound query result for user #{user_id}: #{inspect(join_sound)}")
@@ -43,11 +44,19 @@ defmodule Soundboard.Discord.Handler.SoundEffects do
     case join_sound do
       join_sound when is_binary(join_sound) ->
         Logger.info("Playing join sound immediately: #{join_sound}")
+        maybe_join_for_sound(guild_id, channel_id)
         AudioPlayer.play_sound(join_sound, "System")
 
       _ ->
         Logger.info("No join sound found for user #{user_id}")
         :noop
+    end
+  end
+
+  defp maybe_join_for_sound(guild_id, channel_id) do
+    if AutoJoinPolicy.mode() == :play && VoiceRuntime.get_current_voice_channel() == nil do
+      Logger.info("Auto-joining #{guild_id}/#{channel_id} to play join sound")
+      VoiceRuntime.join_voice_channel(guild_id, channel_id)
     end
   end
 end

--- a/lib/soundboard/discord/handler/voice_presence.ex
+++ b/lib/soundboard/discord/handler/voice_presence.ex
@@ -56,7 +56,9 @@ defmodule Soundboard.Discord.Handler.VoicePresence do
   end
 
   defp find_in_guild(guild, discord_id) do
-    case Enum.find(guild.voice_states, fn vs -> vs.user_id == discord_id end) do
+    target = to_string(discord_id)
+
+    case Enum.find(guild.voice_states, fn vs -> to_string(vs.user_id) == target end) do
       %{channel_id: channel_id} when not is_nil(channel_id) -> {:ok, {guild.id, channel_id}}
       _ -> nil
     end

--- a/lib/soundboard/discord/handler/voice_presence.ex
+++ b/lib/soundboard/discord/handler/voice_presence.ex
@@ -44,6 +44,24 @@ defmodule Soundboard.Discord.Handler.VoicePresence do
     error -> {:error, {:guild_cache_unavailable, Exception.message(error)}}
   end
 
+  def find_user_voice_channel(discord_id) do
+    case cached_guilds() do
+      {:ok, guilds} ->
+        Enum.find_value(guilds, :not_found, &find_in_guild(&1, discord_id))
+
+      {:error, reason} ->
+        Logger.debug("Guild cache unavailable for user voice channel lookup: #{inspect(reason)}")
+        :not_found
+    end
+  end
+
+  defp find_in_guild(guild, discord_id) do
+    case Enum.find(guild.voice_states, fn vs -> vs.user_id == discord_id end) do
+      %{channel_id: channel_id} when not is_nil(channel_id) -> {:ok, {guild.id, channel_id}}
+      _ -> nil
+    end
+  end
+
   def users_in_channel(guild_id, channel_id) do
     cond do
       not valid_discord_id?(guild_id) ->

--- a/lib/soundboard/discord/handler/voice_runtime.ex
+++ b/lib/soundboard/discord/handler/voice_runtime.ex
@@ -31,7 +31,11 @@ defmodule Soundboard.Discord.Handler.VoiceRuntime do
 
   @spec handle_disconnect(map()) :: [runtime_action()]
   def handle_disconnect(payload) do
-    handle_bot_alone_check(payload.guild_id)
+    if bot_user?(payload.user_id) do
+      []
+    else
+      handle_bot_alone_check(payload.guild_id)
+    end
   end
 
   @spec recheck_alone(String.t(), String.t()) :: [runtime_action()]

--- a/lib/soundboard/discord/handler/voice_runtime.ex
+++ b/lib/soundboard/discord/handler/voice_runtime.ex
@@ -11,12 +11,7 @@ defmodule Soundboard.Discord.Handler.VoiceRuntime do
 
   def bootstrap do
     Logger.info("Starting DiscordHandler...")
-
-    case AutoJoinPolicy.mode() do
-      :enabled -> start_guild_check_task()
-      :disabled -> :ok
-    end
-
+    if AutoJoinPolicy.mode() == :presence, do: start_guild_check_task()
     :ok
   end
 
@@ -28,17 +23,15 @@ defmodule Soundboard.Discord.Handler.VoiceRuntime do
   @spec handle_connect(map()) :: [runtime_action()]
   def handle_connect(payload) do
     case AutoJoinPolicy.mode() do
-      :enabled -> handle_auto_join_leave(payload)
-      :disabled -> []
+      :presence -> handle_auto_join_leave(payload)
+      false -> handle_user_rejoin_cancel(payload)
+      :play -> []
     end
   end
 
   @spec handle_disconnect(map()) :: [runtime_action()]
   def handle_disconnect(payload) do
-    case AutoJoinPolicy.mode() do
-      :enabled -> handle_bot_alone_check(payload.guild_id)
-      :disabled -> []
-    end
+    handle_bot_alone_check(payload.guild_id)
   end
 
   @spec recheck_alone(String.t(), String.t()) :: [runtime_action()]
@@ -90,7 +83,6 @@ defmodule Soundboard.Discord.Handler.VoiceRuntime do
 
   defp process_guilds(guilds) do
     Logger.info("Checking #{length(guilds)} guilds for active voice channels")
-
     Enum.each(guilds, &check_and_join_voice/1)
   end
 
@@ -113,32 +105,32 @@ defmodule Soundboard.Discord.Handler.VoiceRuntime do
     case VoicePresence.users_in_channel(guild_id, channel_id) do
       {:ok, users} ->
         Logger.info("Recheck alone: channel #{channel_id} now has #{users} non-bot users")
-        maybe_leave_if_bot_alone(guild_id, channel_id, users)
+        maybe_act_if_bot_alone(guild_id, channel_id, users)
 
       {:error, reason} ->
         Logger.warning("Recheck skipped because voice state was unavailable: #{inspect(reason)}")
     end
   end
 
-  defp maybe_leave_if_bot_alone(guild_id, channel_id, 0) do
-    Logger.info("Recheck confirms bot is alone; leaving channel #{channel_id}")
-    leave_voice_channel(guild_id)
+  defp maybe_act_if_bot_alone(guild_id, _channel_id, 0) do
+    Logger.info("Recheck confirms bot is alone; leaving channel")
+    bot_alone_action(guild_id)
   end
 
-  defp maybe_leave_if_bot_alone(_guild_id, _channel_id, _users), do: :ok
+  defp maybe_act_if_bot_alone(_guild_id, _channel_id, _users), do: :ok
 
   defp handle_bot_alone_check(_guild_id) do
     case current_voice_channel_status() do
-      {:ok, {guild_id, channel_id}} -> check_and_maybe_leave(guild_id, channel_id)
+      {:ok, {guild_id, channel_id}} -> check_and_maybe_act(guild_id, channel_id)
       _ -> []
     end
   end
 
-  defp check_and_maybe_leave(guild_id, channel_id) do
+  defp check_and_maybe_act(guild_id, channel_id) do
     case VoicePresence.users_in_channel(guild_id, channel_id) do
       {:ok, 0} ->
-        Logger.info("No non-bot users remaining in channel, leaving now")
-        leave_voice_channel(guild_id)
+        Logger.info("No non-bot users remaining in channel, acting on bot alone")
+        bot_alone_action(guild_id)
         []
 
       {:ok, users} ->
@@ -154,12 +146,36 @@ defmodule Soundboard.Discord.Handler.VoiceRuntime do
     end
   end
 
+  defp bot_alone_action(guild_id) do
+    case AutoJoinPolicy.mode() do
+      :presence -> leave_voice_channel(guild_id)
+      _ -> AudioPlayer.last_user_left(guild_id)
+    end
+  end
+
   defp handle_auto_join_leave(payload) do
     if bot_user?(payload.user_id) do
       Logger.debug("Ignoring bot's own voice state update in auto-join logic")
       []
     else
       process_user_voice_update(payload)
+    end
+  end
+
+  defp handle_user_rejoin_cancel(payload) do
+    if bot_user?(payload.user_id) do
+      []
+    else
+      case current_voice_channel_status() do
+        {:ok, {guild_id, channel_id}}
+        when guild_id == payload.guild_id and channel_id == payload.channel_id ->
+          Logger.debug("User rejoined bot's channel (false mode); cancelling idle timer")
+          AudioPlayer.user_joined_channel(guild_id)
+          []
+
+        _ ->
+          []
+      end
     end
   end
 

--- a/lib/soundboard_web/controllers/api/sound_controller.ex
+++ b/lib/soundboard_web/controllers/api/sound_controller.ex
@@ -42,9 +42,7 @@ defmodule SoundboardWeb.API.SoundController do
       sound ->
         case require_play_user(conn) do
           {:ok, user} ->
-            actor = %{display_name: user.username, user_id: user.id}
-
-            Soundboard.AudioPlayer.play_sound(sound.filename, actor)
+            Soundboard.AudioPlayer.play_sound(sound.filename, user)
 
             conn
             |> put_status(:accepted)
@@ -52,7 +50,7 @@ defmodule SoundboardWeb.API.SoundController do
               data: %{
                 status: "accepted",
                 message: "Playback request accepted for #{sound.filename}",
-                requested_by: actor.display_name,
+                requested_by: user.username,
                 sound: %{id: sound.id, filename: sound.filename}
               }
             })

--- a/lib/soundboard_web/live/support/sound_playback.ex
+++ b/lib/soundboard_web/live/support/sound_playback.ex
@@ -7,8 +7,8 @@ defmodule SoundboardWeb.Live.Support.SoundPlayback do
 
   def play(socket, sound_name) do
     case socket.assigns[:current_user] do
-      %User{username: username} ->
-        Soundboard.AudioPlayer.play_sound(sound_name, username)
+      %User{} = user ->
+        Soundboard.AudioPlayer.play_sound(sound_name, user)
         {:noreply, socket}
 
       _ ->

--- a/test/soundboard/discord/handler/auto_join_policy_test.exs
+++ b/test/soundboard/discord/handler/auto_join_policy_test.exs
@@ -20,34 +20,45 @@ defmodule Soundboard.Discord.Handler.AutoJoinPolicyTest do
     :ok
   end
 
-  test "mode/0 is always enabled in test" do
+  test "mode/0 is :play in test environment regardless of AUTO_JOIN" do
     Application.put_env(:soundboard, :env, :test)
     System.put_env("AUTO_JOIN", "false")
-
-    assert AutoJoinPolicy.mode() == :enabled
+    assert AutoJoinPolicy.mode() == :play
   end
 
-  test "enabled?/0 recognizes truthy AUTO_JOIN values" do
+  test "defaults to :play when AUTO_JOIN is not set" do
+    Application.put_env(:soundboard, :env, :dev)
+    System.delete_env("AUTO_JOIN")
+    assert AutoJoinPolicy.mode() == :play
+  end
+
+  test "AUTO_JOIN=play returns :play" do
+    Application.put_env(:soundboard, :env, :dev)
+    System.put_env("AUTO_JOIN", "play")
+    assert AutoJoinPolicy.mode() == :play
+  end
+
+  test "AUTO_JOIN=presence returns :presence" do
+    Application.put_env(:soundboard, :env, :dev)
+    System.put_env("AUTO_JOIN", "presence")
+    assert AutoJoinPolicy.mode() == :presence
+  end
+
+  test "truthy values map to :presence" do
     Application.put_env(:soundboard, :env, :dev)
 
     for value <- ["true", "TRUE", "  yes ", "1"] do
       System.put_env("AUTO_JOIN", value)
-      assert AutoJoinPolicy.enabled?()
-      assert AutoJoinPolicy.mode() == :enabled
+      assert AutoJoinPolicy.mode() == :presence
     end
   end
 
-  test "enabled?/0 returns false for missing or non-truthy values" do
+  test "falsy and unknown values map to false" do
     Application.put_env(:soundboard, :env, :dev)
 
-    System.delete_env("AUTO_JOIN")
-    refute AutoJoinPolicy.enabled?()
-    assert AutoJoinPolicy.mode() == :disabled
-
-    for value <- ["false", "0", "no", "later"] do
+    for value <- ["false", "0", "no", "never", "unknown"] do
       System.put_env("AUTO_JOIN", value)
-      refute AutoJoinPolicy.enabled?()
-      assert AutoJoinPolicy.mode() == :disabled
+      assert AutoJoinPolicy.mode() == false
     end
   end
 end

--- a/test/soundboard/discord/handler/idle_timeout_policy_test.exs
+++ b/test/soundboard/discord/handler/idle_timeout_policy_test.exs
@@ -1,0 +1,34 @@
+defmodule Soundboard.Discord.Handler.IdleTimeoutPolicyTest do
+  use ExUnit.Case, async: false
+
+  alias Soundboard.Discord.Handler.IdleTimeoutPolicy
+
+  setup do
+    original = System.get_env("VOICE_IDLE_TIMEOUT_MINUTES")
+
+    on_exit(fn ->
+      if is_nil(original) do
+        System.delete_env("VOICE_IDLE_TIMEOUT_MINUTES")
+      else
+        System.put_env("VOICE_IDLE_TIMEOUT_MINUTES", original)
+      end
+    end)
+
+    :ok
+  end
+
+  test "defaults to 10 minutes when env var is not set" do
+    System.delete_env("VOICE_IDLE_TIMEOUT_MINUTES")
+    assert IdleTimeoutPolicy.timeout_ms() == 10 * 60_000
+  end
+
+  test "reads VOICE_IDLE_TIMEOUT_MINUTES from environment" do
+    System.put_env("VOICE_IDLE_TIMEOUT_MINUTES", "5")
+    assert IdleTimeoutPolicy.timeout_ms() == 5 * 60_000
+  end
+
+  test "handles whitespace around the value" do
+    System.put_env("VOICE_IDLE_TIMEOUT_MINUTES", "  3  ")
+    assert IdleTimeoutPolicy.timeout_ms() == 3 * 60_000
+  end
+end

--- a/test/soundboard/discord/handler/idle_timeout_policy_test.exs
+++ b/test/soundboard/discord/handler/idle_timeout_policy_test.exs
@@ -4,31 +4,41 @@ defmodule Soundboard.Discord.Handler.IdleTimeoutPolicyTest do
   alias Soundboard.Discord.Handler.IdleTimeoutPolicy
 
   setup do
-    original = System.get_env("VOICE_IDLE_TIMEOUT_MINUTES")
+    original = System.get_env("VOICE_IDLE_TIMEOUT_SECONDS")
 
     on_exit(fn ->
       if is_nil(original) do
-        System.delete_env("VOICE_IDLE_TIMEOUT_MINUTES")
+        System.delete_env("VOICE_IDLE_TIMEOUT_SECONDS")
       else
-        System.put_env("VOICE_IDLE_TIMEOUT_MINUTES", original)
+        System.put_env("VOICE_IDLE_TIMEOUT_SECONDS", original)
       end
     end)
 
     :ok
   end
 
-  test "defaults to 10 minutes when env var is not set" do
-    System.delete_env("VOICE_IDLE_TIMEOUT_MINUTES")
-    assert IdleTimeoutPolicy.timeout_ms() == 10 * 60_000
+  test "defaults to 600 seconds (10 minutes) when env var is not set" do
+    System.delete_env("VOICE_IDLE_TIMEOUT_SECONDS")
+    assert IdleTimeoutPolicy.timeout_ms() == 600 * 1_000
   end
 
-  test "reads VOICE_IDLE_TIMEOUT_MINUTES from environment" do
-    System.put_env("VOICE_IDLE_TIMEOUT_MINUTES", "5")
-    assert IdleTimeoutPolicy.timeout_ms() == 5 * 60_000
+  test "reads VOICE_IDLE_TIMEOUT_SECONDS from environment" do
+    System.put_env("VOICE_IDLE_TIMEOUT_SECONDS", "300")
+    assert IdleTimeoutPolicy.timeout_ms() == 300 * 1_000
   end
 
   test "handles whitespace around the value" do
-    System.put_env("VOICE_IDLE_TIMEOUT_MINUTES", "  3  ")
-    assert IdleTimeoutPolicy.timeout_ms() == 3 * 60_000
+    System.put_env("VOICE_IDLE_TIMEOUT_SECONDS", "  30  ")
+    assert IdleTimeoutPolicy.timeout_ms() == 30 * 1_000
+  end
+
+  test "returns nil when set to 0 (disabled)" do
+    System.put_env("VOICE_IDLE_TIMEOUT_SECONDS", "0")
+    assert IdleTimeoutPolicy.timeout_ms() == nil
+  end
+
+  test "returns nil when set to a negative value" do
+    System.put_env("VOICE_IDLE_TIMEOUT_SECONDS", "-1")
+    assert IdleTimeoutPolicy.timeout_ms() == nil
   end
 end

--- a/test/soundboard/discord/handler/idle_timeout_policy_test.exs
+++ b/test/soundboard/discord/handler/idle_timeout_policy_test.exs
@@ -41,4 +41,9 @@ defmodule Soundboard.Discord.Handler.IdleTimeoutPolicyTest do
     System.put_env("VOICE_IDLE_TIMEOUT_SECONDS", "-1")
     assert IdleTimeoutPolicy.timeout_ms() == nil
   end
+
+  test "falls back to default when value is non-numeric" do
+    System.put_env("VOICE_IDLE_TIMEOUT_SECONDS", "ten")
+    assert IdleTimeoutPolicy.timeout_ms() == 600 * 1_000
+  end
 end

--- a/test/soundboard/discord/handler/voice_presence_test.exs
+++ b/test/soundboard/discord/handler/voice_presence_test.exs
@@ -1,0 +1,77 @@
+defmodule Soundboard.Discord.Handler.VoicePresenceTest do
+  use ExUnit.Case, async: false
+
+  import Mock
+
+  alias Soundboard.Discord.GuildCache
+  alias Soundboard.Discord.Handler.VoicePresence
+
+  describe "find_user_voice_channel/1" do
+    test "returns {:ok, {guild_id, channel_id}} when user is in a voice channel" do
+      guilds = [
+        %{
+          id: "guild-1",
+          voice_states: [
+            %{user_id: "user-99", channel_id: "ch-5", guild_id: "guild-1", session_id: "s1"}
+          ]
+        }
+      ]
+
+      with_mock GuildCache, all: fn -> guilds end do
+        assert VoicePresence.find_user_voice_channel("user-99") == {:ok, {"guild-1", "ch-5"}}
+      end
+    end
+
+    test "returns :not_found when user is in no guild" do
+      guilds = [
+        %{
+          id: "guild-1",
+          voice_states: [
+            %{user_id: "other-user", channel_id: "ch-5", guild_id: "guild-1", session_id: "s1"}
+          ]
+        }
+      ]
+
+      with_mock GuildCache, all: fn -> guilds end do
+        assert VoicePresence.find_user_voice_channel("user-99") == :not_found
+      end
+    end
+
+    test "returns :not_found when user has no channel_id" do
+      guilds = [
+        %{
+          id: "guild-1",
+          voice_states: [
+            %{user_id: "user-99", channel_id: nil, guild_id: "guild-1", session_id: "s1"}
+          ]
+        }
+      ]
+
+      with_mock GuildCache, all: fn -> guilds end do
+        assert VoicePresence.find_user_voice_channel("user-99") == :not_found
+      end
+    end
+
+    test "searches across multiple guilds" do
+      guilds = [
+        %{id: "guild-1", voice_states: []},
+        %{
+          id: "guild-2",
+          voice_states: [
+            %{user_id: "user-99", channel_id: "ch-7", guild_id: "guild-2", session_id: "s2"}
+          ]
+        }
+      ]
+
+      with_mock GuildCache, all: fn -> guilds end do
+        assert VoicePresence.find_user_voice_channel("user-99") == {:ok, {"guild-2", "ch-7"}}
+      end
+    end
+
+    test "returns :not_found when guild cache is unavailable" do
+      with_mock GuildCache, all: fn -> raise "cache unavailable" end do
+        assert VoicePresence.find_user_voice_channel("user-99") == :not_found
+      end
+    end
+  end
+end

--- a/test/soundboard/discord/handler/voice_runtime_test.exs
+++ b/test/soundboard/discord/handler/voice_runtime_test.exs
@@ -4,13 +4,14 @@ defmodule Soundboard.Discord.Handler.VoiceRuntimeTest do
   import ExUnit.CaptureLog
   import Mock
 
+  alias Soundboard.AudioPlayer
   alias Soundboard.Discord.Handler.{AutoJoinPolicy, VoicePresence, VoiceRuntime}
 
   test "handle_disconnect returns a recheck action instead of scheduling directly" do
     payload = %{guild_id: "guild-1"}
 
     with_mocks([
-      {AutoJoinPolicy, [], [mode: fn -> :enabled end]},
+      {AutoJoinPolicy, [], [mode: fn -> :presence end]},
       {VoicePresence, [],
        [
          current_voice_channel: fn -> {:ok, {"guild-1", "channel-1"}} end,
@@ -27,7 +28,7 @@ defmodule Soundboard.Discord.Handler.VoiceRuntimeTest do
     payload = %{guild_id: "guild-1", channel_id: "channel-2", user_id: "user-1"}
 
     with_mocks([
-      {AutoJoinPolicy, [], [mode: fn -> :enabled end]},
+      {AutoJoinPolicy, [], [mode: fn -> :presence end]},
       {VoicePresence, [],
        [
          bot_user?: fn "user-1" -> false end,
@@ -70,17 +71,118 @@ defmodule Soundboard.Discord.Handler.VoiceRuntimeTest do
     }
 
     with_mocks([
-      {AutoJoinPolicy, [], [mode: fn -> :enabled end]},
+      {AutoJoinPolicy, [], [mode: fn -> :presence end]},
       {VoicePresence, [],
        [cached_guilds: fn -> {:ok, [guild]} end, bot_id: fn -> {:ok, "bot-1"} end]},
       {Soundboard.Discord.Voice, [],
        [join_channel: fn "guild-1", "channel-9" -> send(test_pid, :joined_bootstrap_channel) end]},
-      {Soundboard.AudioPlayer, [],
+      {AudioPlayer, [],
        [set_voice_channel: fn "guild-1", "channel-9" -> send(test_pid, :set_bootstrap_voice) end]}
     ]) do
       assert :ok = VoiceRuntime.bootstrap()
       assert_receive :joined_bootstrap_channel, 6_000
       assert_receive :set_bootstrap_voice, 1_000
+    end
+  end
+
+  test "bootstrap skips guild check in play mode" do
+    with_mock AutoJoinPolicy, mode: fn -> :play end do
+      assert :ok = VoiceRuntime.bootstrap()
+      # No Task spawned, nothing to assert — just verify it returns :ok without hanging
+    end
+  end
+
+  test "handle_disconnect notifies AudioPlayer when bot is alone in play mode" do
+    test_pid = self()
+    payload = %{guild_id: "guild-1"}
+
+    with_mocks([
+      {AutoJoinPolicy, [], [mode: fn -> :play end]},
+      {VoicePresence, [],
+       [
+         current_voice_channel: fn -> {:ok, {"guild-1", "channel-1"}} end,
+         users_in_channel: fn "guild-1", "channel-1" -> {:ok, 0} end
+       ]},
+      {AudioPlayer, [],
+       [
+         last_user_left: fn "guild-1" ->
+           send(test_pid, :last_user_left_called)
+         end
+       ]}
+    ]) do
+      VoiceRuntime.handle_disconnect(payload)
+      assert_receive :last_user_left_called, 1_000
+    end
+  end
+
+  test "handle_disconnect notifies AudioPlayer when bot is alone in false mode" do
+    test_pid = self()
+    payload = %{guild_id: "guild-1"}
+
+    with_mocks([
+      {AutoJoinPolicy, [], [mode: fn -> false end]},
+      {VoicePresence, [],
+       [
+         current_voice_channel: fn -> {:ok, {"guild-1", "channel-1"}} end,
+         users_in_channel: fn "guild-1", "channel-1" -> {:ok, 0} end
+       ]},
+      {AudioPlayer, [],
+       [
+         last_user_left: fn "guild-1" ->
+           send(test_pid, :last_user_left_called)
+         end
+       ]}
+    ]) do
+      VoiceRuntime.handle_disconnect(payload)
+      assert_receive :last_user_left_called, 1_000
+    end
+  end
+
+  test "handle_connect in false mode cancels idle timer when user joins bot's channel" do
+    test_pid = self()
+    payload = %{guild_id: "guild-1", channel_id: "channel-1", user_id: "user-1"}
+
+    with_mocks([
+      {AutoJoinPolicy, [], [mode: fn -> false end]},
+      {VoicePresence, [],
+       [
+         bot_user?: fn "user-1" -> false end,
+         current_voice_channel: fn -> {:ok, {"guild-1", "channel-1"}} end
+       ]},
+      {AudioPlayer, [],
+       [
+         user_joined_channel: fn "guild-1" ->
+           send(test_pid, :user_joined_called)
+         end
+       ]}
+    ]) do
+      VoiceRuntime.handle_connect(payload)
+      assert_receive :user_joined_called, 1_000
+    end
+  end
+
+  test "handle_connect in false mode ignores joins to other channels" do
+    payload = %{guild_id: "guild-1", channel_id: "channel-2", user_id: "user-1"}
+
+    with_mocks([
+      {AutoJoinPolicy, [], [mode: fn -> false end]},
+      {VoicePresence, [],
+       [
+         bot_user?: fn "user-1" -> false end,
+         current_voice_channel: fn -> {:ok, {"guild-1", "channel-1"}} end
+       ]},
+      {AudioPlayer, [], [user_joined_channel: fn _ -> :ok end]}
+    ]) do
+      VoiceRuntime.handle_connect(payload)
+      refute called(AudioPlayer.user_joined_channel(:_))
+    end
+  end
+
+  test "handle_connect returns [] in play mode" do
+    payload = %{guild_id: "guild-1", channel_id: "channel-1", user_id: "user-1"}
+
+    with_mock AutoJoinPolicy, mode: fn -> :play end do
+      assert VoiceRuntime.handle_connect(payload) == []
     end
   end
 end

--- a/test/soundboard/discord/handler/voice_runtime_test.exs
+++ b/test/soundboard/discord/handler/voice_runtime_test.exs
@@ -8,12 +8,13 @@ defmodule Soundboard.Discord.Handler.VoiceRuntimeTest do
   alias Soundboard.Discord.Handler.{AutoJoinPolicy, VoicePresence, VoiceRuntime}
 
   test "handle_disconnect returns a recheck action instead of scheduling directly" do
-    payload = %{guild_id: "guild-1"}
+    payload = %{guild_id: "guild-1", user_id: "user-1"}
 
     with_mocks([
       {AutoJoinPolicy, [], [mode: fn -> :presence end]},
       {VoicePresence, [],
        [
+         bot_user?: fn "user-1" -> false end,
          current_voice_channel: fn -> {:ok, {"guild-1", "channel-1"}} end,
          users_in_channel: fn "guild-1", "channel-1" -> {:ok, 2} end
        ]}
@@ -94,12 +95,13 @@ defmodule Soundboard.Discord.Handler.VoiceRuntimeTest do
 
   test "handle_disconnect notifies AudioPlayer when bot is alone in play mode" do
     test_pid = self()
-    payload = %{guild_id: "guild-1"}
+    payload = %{guild_id: "guild-1", user_id: "user-1"}
 
     with_mocks([
       {AutoJoinPolicy, [], [mode: fn -> :play end]},
       {VoicePresence, [],
        [
+         bot_user?: fn "user-1" -> false end,
          current_voice_channel: fn -> {:ok, {"guild-1", "channel-1"}} end,
          users_in_channel: fn "guild-1", "channel-1" -> {:ok, 0} end
        ]},
@@ -117,12 +119,13 @@ defmodule Soundboard.Discord.Handler.VoiceRuntimeTest do
 
   test "handle_disconnect notifies AudioPlayer when bot is alone in false mode" do
     test_pid = self()
-    payload = %{guild_id: "guild-1"}
+    payload = %{guild_id: "guild-1", user_id: "user-1"}
 
     with_mocks([
       {AutoJoinPolicy, [], [mode: fn -> false end]},
       {VoicePresence, [],
        [
+         bot_user?: fn "user-1" -> false end,
          current_voice_channel: fn -> {:ok, {"guild-1", "channel-1"}} end,
          users_in_channel: fn "guild-1", "channel-1" -> {:ok, 0} end
        ]},
@@ -175,6 +178,18 @@ defmodule Soundboard.Discord.Handler.VoiceRuntimeTest do
     ]) do
       VoiceRuntime.handle_connect(payload)
       refute called(AudioPlayer.user_joined_channel(:_))
+    end
+  end
+
+  test "handle_disconnect ignores the bot's own voice disconnect" do
+    payload = %{guild_id: "guild-1", user_id: "bot-999"}
+
+    with_mocks([
+      {VoicePresence, [], [bot_user?: fn "bot-999" -> true end]},
+      {AudioPlayer, [], [last_user_left: fn _ -> :ok end]}
+    ]) do
+      assert VoiceRuntime.handle_disconnect(payload) == []
+      refute called(AudioPlayer.last_user_left(:_))
     end
   end
 

--- a/test/soundboard_web/audio_player_test.exs
+++ b/test/soundboard_web/audio_player_test.exs
@@ -3,8 +3,11 @@ defmodule Soundboard.AudioPlayerTest do
 
   import Mock
 
+  alias Soundboard.Accounts.User
   alias Soundboard.AudioPlayer
   alias Soundboard.AudioPlayer.State
+  alias Soundboard.Discord.Handler.VoicePresence
+  alias Soundboard.Discord.Voice
 
   setup do
     original_state = :sys.get_state(AudioPlayer)
@@ -30,7 +33,7 @@ defmodule Soundboard.AudioPlayerTest do
       }
     end)
 
-    with_mock Soundboard.Discord.Voice,
+    with_mock Voice,
       channel_id: fn "guild-1" -> "channel-1" end,
       ready?: fn "guild-1" -> false end,
       playing?: fn "guild-1" -> raise "playback status unavailable" end,
@@ -43,6 +46,192 @@ defmodule Soundboard.AudioPlayerTest do
 
       # leave→rejoin includes a 1s sleep between leave and join
       assert_receive :join_attempted, 2_000
+    end
+  end
+
+  describe "idle timeout" do
+    test "schedules idle timeout when voice channel is set" do
+      :sys.replace_state(AudioPlayer, fn state ->
+        %{state | voice_channel: nil, idle_timeout_ref: nil}
+      end)
+
+      AudioPlayer.set_voice_channel("guild-1", "ch-1")
+      # Sync: the call queues after the cast, ensuring the cast is processed first
+      AudioPlayer.current_voice_channel()
+
+      state = :sys.get_state(AudioPlayer)
+      assert state.voice_channel == {"guild-1", "ch-1"}
+      assert state.idle_timeout_ref != nil
+    end
+
+    test "cancels idle timeout when voice channel is cleared" do
+      :sys.replace_state(AudioPlayer, fn state ->
+        %{state | voice_channel: {"guild-1", "ch-1"}, idle_timeout_ref: {make_ref(), make_ref()}}
+      end)
+
+      AudioPlayer.set_voice_channel(nil, nil)
+      AudioPlayer.current_voice_channel()
+
+      state = :sys.get_state(AudioPlayer)
+      assert state.voice_channel == nil
+      assert state.idle_timeout_ref == nil
+    end
+
+    test "resets idle timeout when a sound is played" do
+      token = make_ref()
+
+      :sys.replace_state(AudioPlayer, fn state ->
+        %{
+          state
+          | voice_channel: {"guild-1", "ch-1"},
+            idle_timeout_ref: {make_ref(), token},
+            current_playback: nil,
+            pending_request: nil,
+            interrupting: false,
+            interrupt_watchdog_attempt: 0
+        }
+      end)
+
+      with_mocks([
+        {Soundboard.AudioPlayer.SoundLibrary, [],
+         [get_sound_path: fn "test.mp3" -> {:ok, {"/path/test.mp3", 1.0}} end]},
+        {Soundboard.AudioPlayer.PlaybackEngine, [], [play: fn _, _, _, _, _, _ -> :ok end]}
+      ]) do
+        AudioPlayer.play_sound("test.mp3", "actor")
+        AudioPlayer.current_voice_channel()
+
+        state = :sys.get_state(AudioPlayer)
+        # A new token means the timer was reset
+        {_ref, new_token} = state.idle_timeout_ref
+        assert new_token != token
+      end
+    end
+
+    test "idle timeout fires and leaves the voice channel" do
+      test_pid = self()
+      token = make_ref()
+
+      :sys.replace_state(AudioPlayer, fn state ->
+        %{
+          state
+          | voice_channel: {"guild-1", "ch-1"},
+            idle_timeout_ref: {make_ref(), token},
+            current_playback: nil
+        }
+      end)
+
+      with_mock Voice,
+        leave_channel: fn "guild-1" ->
+          send(test_pid, :leave_called)
+          :ok
+        end do
+        send(AudioPlayer, {:idle_timeout, token})
+        assert_receive :leave_called, 1_000
+
+        AudioPlayer.current_voice_channel()
+        state = :sys.get_state(AudioPlayer)
+        assert state.voice_channel == nil
+        assert state.idle_timeout_ref == nil
+      end
+    end
+
+    test "stale idle timeout tokens are ignored" do
+      test_pid = self()
+      active_token = make_ref()
+      stale_token = make_ref()
+
+      :sys.replace_state(AudioPlayer, fn state ->
+        %{
+          state
+          | voice_channel: {"guild-1", "ch-1"},
+            idle_timeout_ref: {make_ref(), active_token}
+        }
+      end)
+
+      with_mock Voice,
+        leave_channel: fn _ ->
+          send(test_pid, :leave_called)
+          :ok
+        end do
+        send(AudioPlayer, {:idle_timeout, stale_token})
+        # Sync, then verify nothing happened
+        AudioPlayer.current_voice_channel()
+        refute_receive :leave_called, 100
+
+        state = :sys.get_state(AudioPlayer)
+        assert state.voice_channel == {"guild-1", "ch-1"}
+      end
+    end
+  end
+
+  describe "auto-join on play" do
+    test "auto-joins user's voice channel when bot has no channel and actor has discord_id" do
+      test_pid = self()
+      user = %User{discord_id: "discord-99", username: "tester", id: 1}
+
+      :sys.replace_state(AudioPlayer, fn state ->
+        %{state | voice_channel: nil, idle_timeout_ref: nil}
+      end)
+
+      with_mocks([
+        {VoicePresence, [],
+         [find_user_voice_channel: fn "discord-99" -> {:ok, {"guild-1", "ch-5"}} end]},
+        {Voice, [],
+         [
+           join_channel: fn "guild-1", "ch-5" ->
+             send(test_pid, :join_called)
+             :ok
+           end
+         ]},
+        {Soundboard.AudioPlayer.SoundLibrary, [],
+         [get_sound_path: fn _ -> {:error, "not found"} end]}
+      ]) do
+        AudioPlayer.play_sound("any.mp3", user)
+        assert_receive :join_called, 1_000
+
+        AudioPlayer.current_voice_channel()
+        state = :sys.get_state(AudioPlayer)
+        assert state.voice_channel == {"guild-1", "ch-5"}
+        assert state.idle_timeout_ref != nil
+      end
+    end
+
+    test "shows error and skips auto-join when user is not in any voice channel" do
+      user = %User{discord_id: "discord-99", username: "tester", id: 1}
+
+      :sys.replace_state(AudioPlayer, fn state ->
+        %{state | voice_channel: nil, idle_timeout_ref: nil}
+      end)
+
+      with_mocks([
+        {VoicePresence, [], [find_user_voice_channel: fn "discord-99" -> :not_found end]},
+        {Voice, [], [join_channel: fn _, _ -> :ok end]}
+      ]) do
+        AudioPlayer.play_sound("any.mp3", user)
+        AudioPlayer.current_voice_channel()
+
+        state = :sys.get_state(AudioPlayer)
+        assert state.voice_channel == nil
+
+        refute called(Voice.join_channel(:_, :_))
+      end
+    end
+
+    test "skips auto-join for actors without discord_id" do
+      :sys.replace_state(AudioPlayer, fn state ->
+        %{state | voice_channel: nil, idle_timeout_ref: nil}
+      end)
+
+      with_mocks([
+        {VoicePresence, [], [find_user_voice_channel: fn _ -> {:ok, {"guild-1", "ch-1"}} end]},
+        {Voice, [], [join_channel: fn _, _ -> :ok end]}
+      ]) do
+        AudioPlayer.play_sound("any.mp3", "System")
+        AudioPlayer.current_voice_channel()
+
+        refute called(VoicePresence.find_user_voice_channel(:_))
+        refute called(Voice.join_channel(:_, :_))
+      end
     end
   end
 end

--- a/test/soundboard_web/audio_player_test.exs
+++ b/test/soundboard_web/audio_player_test.exs
@@ -6,7 +6,7 @@ defmodule Soundboard.AudioPlayerTest do
   alias Soundboard.Accounts.User
   alias Soundboard.AudioPlayer
   alias Soundboard.AudioPlayer.State
-  alias Soundboard.Discord.Handler.VoicePresence
+  alias Soundboard.Discord.Handler.{AutoJoinPolicy, VoicePresence}
   alias Soundboard.Discord.Voice
 
   setup do
@@ -50,7 +50,7 @@ defmodule Soundboard.AudioPlayerTest do
   end
 
   describe "idle timeout" do
-    test "schedules idle timeout when voice channel is set" do
+    test "schedules idle timeout when voice channel is set (play mode)" do
       :sys.replace_state(AudioPlayer, fn state ->
         %{state | voice_channel: nil, idle_timeout_ref: nil}
       end)
@@ -62,6 +62,36 @@ defmodule Soundboard.AudioPlayerTest do
       state = :sys.get_state(AudioPlayer)
       assert state.voice_channel == {"guild-1", "ch-1"}
       assert state.idle_timeout_ref != nil
+    end
+
+    test "does not schedule idle timeout in presence mode" do
+      :sys.replace_state(AudioPlayer, fn state ->
+        %{state | voice_channel: nil, idle_timeout_ref: nil}
+      end)
+
+      with_mock AutoJoinPolicy, mode: fn -> :presence end do
+        AudioPlayer.set_voice_channel("guild-1", "ch-1")
+        AudioPlayer.current_voice_channel()
+
+        state = :sys.get_state(AudioPlayer)
+        assert state.voice_channel == {"guild-1", "ch-1"}
+        assert state.idle_timeout_ref == nil
+      end
+    end
+
+    test "does not schedule idle timeout in false mode on join" do
+      :sys.replace_state(AudioPlayer, fn state ->
+        %{state | voice_channel: nil, idle_timeout_ref: nil}
+      end)
+
+      with_mock AutoJoinPolicy, mode: fn -> false end do
+        AudioPlayer.set_voice_channel("guild-1", "ch-1")
+        AudioPlayer.current_voice_channel()
+
+        state = :sys.get_state(AudioPlayer)
+        assert state.voice_channel == {"guild-1", "ch-1"}
+        assert state.idle_timeout_ref == nil
+      end
     end
 
     test "cancels idle timeout when voice channel is cleared" do
@@ -77,7 +107,7 @@ defmodule Soundboard.AudioPlayerTest do
       assert state.idle_timeout_ref == nil
     end
 
-    test "resets idle timeout when a sound is played" do
+    test "resets idle timeout when a sound is played (play mode)" do
       token = make_ref()
 
       :sys.replace_state(AudioPlayer, fn state ->
@@ -104,6 +134,36 @@ defmodule Soundboard.AudioPlayerTest do
         # A new token means the timer was reset
         {_ref, new_token} = state.idle_timeout_ref
         assert new_token != token
+      end
+    end
+
+    test "does not reset idle timeout when a sound is played in presence mode" do
+      token = make_ref()
+
+      :sys.replace_state(AudioPlayer, fn state ->
+        %{
+          state
+          | voice_channel: {"guild-1", "ch-1"},
+            idle_timeout_ref: {make_ref(), token},
+            current_playback: nil,
+            pending_request: nil,
+            interrupting: false,
+            interrupt_watchdog_attempt: 0
+        }
+      end)
+
+      with_mocks([
+        {AutoJoinPolicy, [], [mode: fn -> :presence end]},
+        {Soundboard.AudioPlayer.SoundLibrary, [],
+         [get_sound_path: fn "test.mp3" -> {:ok, {"/path/test.mp3", 1.0}} end]},
+        {Soundboard.AudioPlayer.PlaybackEngine, [], [play: fn _, _, _, _, _, _ -> :ok end]}
+      ]) do
+        AudioPlayer.play_sound("test.mp3", "actor")
+        AudioPlayer.current_voice_channel()
+
+        state = :sys.get_state(AudioPlayer)
+        {_ref, unchanged_token} = state.idle_timeout_ref
+        assert unchanged_token == token
       end
     end
 
@@ -161,6 +221,125 @@ defmodule Soundboard.AudioPlayerTest do
         state = :sys.get_state(AudioPlayer)
         assert state.voice_channel == {"guild-1", "ch-1"}
       end
+    end
+  end
+
+  describe "last_user_left" do
+    test "leaves immediately in play mode" do
+      test_pid = self()
+
+      :sys.replace_state(AudioPlayer, fn state ->
+        %{state | voice_channel: {"guild-1", "ch-1"}, idle_timeout_ref: nil}
+      end)
+
+      with_mock Voice,
+        leave_channel: fn "guild-1" ->
+          send(test_pid, :leave_called)
+          :ok
+        end do
+        AudioPlayer.last_user_left("guild-1")
+        assert_receive :leave_called, 1_000
+
+        AudioPlayer.current_voice_channel()
+        state = :sys.get_state(AudioPlayer)
+        assert state.voice_channel == nil
+        assert state.idle_timeout_ref == nil
+      end
+    end
+
+    test "leaves immediately in presence mode" do
+      test_pid = self()
+
+      :sys.replace_state(AudioPlayer, fn state ->
+        %{state | voice_channel: {"guild-1", "ch-1"}, idle_timeout_ref: nil}
+      end)
+
+      with_mocks([
+        {AutoJoinPolicy, [], [mode: fn -> :presence end]},
+        {Voice, [],
+         [
+           leave_channel: fn "guild-1" ->
+             send(test_pid, :leave_called)
+             :ok
+           end
+         ]}
+      ]) do
+        AudioPlayer.last_user_left("guild-1")
+        assert_receive :leave_called, 1_000
+
+        AudioPlayer.current_voice_channel()
+        state = :sys.get_state(AudioPlayer)
+        assert state.voice_channel == nil
+      end
+    end
+
+    test "starts idle timer in false mode (with timeout configured)" do
+      :sys.replace_state(AudioPlayer, fn state ->
+        %{state | voice_channel: {"guild-1", "ch-1"}, idle_timeout_ref: nil}
+      end)
+
+      with_mocks([
+        {AutoJoinPolicy, [], [mode: fn -> false end]},
+        {Soundboard.Discord.Handler.IdleTimeoutPolicy, [], [timeout_ms: fn -> 60_000 end]},
+        {Voice, [], [leave_channel: fn _ -> :ok end]}
+      ]) do
+        AudioPlayer.last_user_left("guild-1")
+        AudioPlayer.current_voice_channel()
+
+        state = :sys.get_state(AudioPlayer)
+        assert state.voice_channel == {"guild-1", "ch-1"}
+        assert state.idle_timeout_ref != nil
+        refute called(Voice.leave_channel(:_))
+      end
+    end
+
+    test "stays in false mode when timeout is disabled (0)" do
+      :sys.replace_state(AudioPlayer, fn state ->
+        %{state | voice_channel: {"guild-1", "ch-1"}, idle_timeout_ref: nil}
+      end)
+
+      with_mocks([
+        {AutoJoinPolicy, [], [mode: fn -> false end]},
+        {Soundboard.Discord.Handler.IdleTimeoutPolicy, [], [timeout_ms: fn -> nil end]},
+        {Voice, [], [leave_channel: fn _ -> :ok end]}
+      ]) do
+        AudioPlayer.last_user_left("guild-1")
+        AudioPlayer.current_voice_channel()
+
+        state = :sys.get_state(AudioPlayer)
+        assert state.voice_channel == {"guild-1", "ch-1"}
+        assert state.idle_timeout_ref == nil
+        refute called(Voice.leave_channel(:_))
+      end
+    end
+
+    test "ignores last_user_left when bot is not in a channel" do
+      :sys.replace_state(AudioPlayer, fn state ->
+        %{state | voice_channel: nil}
+      end)
+
+      with_mock Voice, leave_channel: fn _ -> :ok end do
+        AudioPlayer.last_user_left("guild-1")
+        AudioPlayer.current_voice_channel()
+
+        refute called(Voice.leave_channel(:_))
+      end
+    end
+  end
+
+  describe "user_joined_channel" do
+    test "cancels idle timer" do
+      token = make_ref()
+
+      :sys.replace_state(AudioPlayer, fn state ->
+        %{state | voice_channel: {"guild-1", "ch-1"}, idle_timeout_ref: {make_ref(), token}}
+      end)
+
+      AudioPlayer.user_joined_channel("guild-1")
+      AudioPlayer.current_voice_channel()
+
+      state = :sys.get_state(AudioPlayer)
+      assert state.idle_timeout_ref == nil
     end
   end
 
@@ -227,6 +406,26 @@ defmodule Soundboard.AudioPlayerTest do
         {Voice, [], [join_channel: fn _, _ -> :ok end]}
       ]) do
         AudioPlayer.play_sound("any.mp3", "System")
+        AudioPlayer.current_voice_channel()
+
+        refute called(VoicePresence.find_user_voice_channel(:_))
+        refute called(Voice.join_channel(:_, :_))
+      end
+    end
+
+    test "skips auto-join in false mode" do
+      user = %User{discord_id: "discord-99", username: "tester", id: 1}
+
+      :sys.replace_state(AudioPlayer, fn state ->
+        %{state | voice_channel: nil, idle_timeout_ref: nil}
+      end)
+
+      with_mocks([
+        {AutoJoinPolicy, [], [mode: fn -> false end]},
+        {VoicePresence, [], [find_user_voice_channel: fn _ -> {:ok, {"guild-1", "ch-1"}} end]},
+        {Voice, [], [join_channel: fn _, _ -> :ok end]}
+      ]) do
+        AudioPlayer.play_sound("any.mp3", user)
         AudioPlayer.current_voice_channel()
 
         refute called(VoicePresence.find_user_voice_channel(:_))

--- a/test/soundboard_web/controllers/api/sound_controller_test.exs
+++ b/test/soundboard_web/controllers/api/sound_controller_test.exs
@@ -269,8 +269,6 @@ defmodule SoundboardWeb.API.SoundControllerTest do
 
   describe "play" do
     test "plays a sound as the authenticated token user", %{conn: conn, sound: sound, user: user} do
-      actor = %{display_name: user.username, user_id: user.id}
-
       with_mock Soundboard.AudioPlayer, play_sound: fn _filename, _actor -> :ok end do
         conn = post(conn, ~p"/api/sounds/#{sound.id}/play")
 
@@ -286,7 +284,7 @@ defmodule SoundboardWeb.API.SoundControllerTest do
         assert requested_by == user.username
         assert sound_id == sound.id
         assert filename == sound.filename
-        assert_called(Soundboard.AudioPlayer.play_sound(sound.filename, actor))
+        assert_called(Soundboard.AudioPlayer.play_sound(sound.filename, user))
       end
     end
 
@@ -295,8 +293,6 @@ defmodule SoundboardWeb.API.SoundControllerTest do
       sound: sound,
       user: user
     } do
-      actor = %{display_name: user.username, user_id: user.id}
-
       with_mock Soundboard.AudioPlayer, play_sound: fn _filename, _actor -> :ok end do
         conn =
           conn
@@ -313,7 +309,7 @@ defmodule SoundboardWeb.API.SoundControllerTest do
         assert requested_by == user.username
         assert sound_id == sound.id
         assert filename == sound.filename
-        assert_called(Soundboard.AudioPlayer.play_sound(sound.filename, actor))
+        assert_called(Soundboard.AudioPlayer.play_sound(sound.filename, user))
       end
     end
 

--- a/test/soundboard_web/discord_handler_test.exs
+++ b/test/soundboard_web/discord_handler_test.exs
@@ -37,6 +37,7 @@ defmodule Soundboard.Discord.HandlerTest do
 
       capture_log(fn ->
         with_mocks([
+          {Soundboard.Discord.Handler.AutoJoinPolicy, [], [mode: fn -> :presence end]},
           {Soundboard.Discord.Voice, [],
            [
              join_channel: fn _, _ -> :ok end,
@@ -166,21 +167,14 @@ defmodule Soundboard.Discord.HandlerTest do
              get: fn ^guild_id -> {:ok, guild} end
            ]},
           {Soundboard.Discord.BotIdentity, [], [fetch: fn -> {:ok, %{id: bot_id}} end]},
-          {Soundboard.Discord.Voice, [],
-           [
-             leave_channel: fn ^guild_id ->
-               Agent.update(recorder, &(&1 ++ [:leave_channel]))
-               :ok
-             end
-           ]},
           {Soundboard.AudioPlayer, [],
            [
              play_sound: fn filename, played_by ->
                Agent.update(recorder, &(&1 ++ [{:play_sound, filename, played_by}]))
                :ok
              end,
-             set_voice_channel: fn guild, channel ->
-               Agent.update(recorder, &(&1 ++ [{:set_voice_channel, guild, channel}]))
+             last_user_left: fn guild ->
+               Agent.update(recorder, &(&1 ++ [{:last_user_left, guild}]))
                :ok
              end
            ]}
@@ -196,8 +190,7 @@ defmodule Soundboard.Discord.HandlerTest do
 
           assert Agent.get(recorder, & &1) == [
                    {:play_sound, "leave.mp3", "System"},
-                   :leave_channel,
-                   {:set_voice_channel, nil, nil}
+                   {:last_user_left, guild_id}
                  ]
         end
       end)

--- a/test/soundboard_web/live/favorites_live_test.exs
+++ b/test/soundboard_web/live/favorites_live_test.exs
@@ -72,7 +72,7 @@ defmodule SoundboardWeb.FavoritesLiveTest do
       |> element("[phx-click='play'][phx-value-name='#{sound.filename}']")
       |> render_click()
 
-      assert_called(Soundboard.AudioPlayer.play_sound(sound.filename, user.username))
+      assert_called(Soundboard.AudioPlayer.play_sound(sound.filename, user))
     end
   end
 

--- a/test/soundboard_web/plugs/api_auth_db_token_test.exs
+++ b/test/soundboard_web/plugs/api_auth_db_token_test.exs
@@ -41,8 +41,6 @@ defmodule SoundboardWeb.APIAuthDBTokenTest do
     sound: sound,
     user: user
   } do
-    actor = %{display_name: user.username, user_id: user.id}
-
     # Mock the audio player so we don't actually attempt voice playback
     with_mock Soundboard.AudioPlayer, play_sound: fn _, _ -> :ok end do
       conn = post(conn, ~p"/api/sounds/#{sound.id}/play")
@@ -56,7 +54,7 @@ defmodule SoundboardWeb.APIAuthDBTokenTest do
 
       assert sound_id == sound.id
       assert filename == sound.filename
-      assert_called(Soundboard.AudioPlayer.play_sound(sound.filename, actor))
+      assert_called(Soundboard.AudioPlayer.play_sound(sound.filename, user))
     end
   end
 


### PR DESCRIPTION
## Summary

- **`AUTO_JOIN` mode enum**: replaces the old boolean with `play` (default) / `presence` / `false`, unifying join and leave behavior into one setting
- **Auto-join on play** (`play` mode): bot automatically joins the user's current voice channel when a sound is played from the web UI or API
- **Mode-aware idle auto-leave**: timer semantics differ by mode (see table below)
- **`VOICE_IDLE_TIMEOUT_SECONDS`**: replaces `VOICE_IDLE_TIMEOUT_MINUTES`; set to `0` to disable; default 600
- **`BIND_IP`** now actually wires to the HTTP listener binding (was documented but not applied)

## Mode behavior

| Mode | How bot joins | How bot leaves |
|---|---|---|
| `play` (default) | Joins when a sound is played | Last user leaves immediately **or** idle timeout (whichever first); timeout `0` → last user only |
| `presence` | Follows users into channels on voice-state updates | Last user leaves immediately; idle timeout ignored |
| `false` | Manual `!join` only | Idle timer starts when last user leaves, cancels if someone rejoins; timeout `0` → never auto-leaves |

`AUTO_JOIN=true` still works as an alias for `presence`.

## Design notes

- Actor changed from username string / display-name map to full `%User{}` struct so `discord_id` is available for voice lookup.
- Auto-join calls `Voice.join_channel` directly inside `handle_cast` (avoids circular dep: `VoiceCommands` → `AudioPlayer.set_voice_channel`).
- Idle timer uses `{ref, token}` to silently discard stale messages when `cancel_timer` races with delivery — same pattern as the interrupt watchdog.
- `VoiceRuntime.handle_disconnect` now runs the alone-check for all modes; `bot_alone_action/1` dispatches to either `VoiceCommands.leave_voice_channel` (`:presence`) or `AudioPlayer.last_user_left/1` (`:play` / `false`).
- `AudioPlayer.last_user_left/1` and `user_joined_channel/1` are new public entry points; `VoiceRuntime` sends these instead of calling `Voice.leave_channel` directly for non-presence modes.
- `IdleTimeoutPolicy.timeout_ms/0` returns `nil` when `≤ 0` — callers treat `nil` as disabled and skip scheduling.
- `find_user_voice_channel/1` normalises both sides with `to_string/1` before comparison (defensive type safety, consistent with `bot_user?/1`).
- `IdleTimeoutPolicy` uses `Integer.parse/1` with a fallback instead of `String.to_integer/1` so a malformed env var logs a warning and uses the default rather than crashing AudioPlayer.

Spec: `docs/specs/voice-auto-join-idle-leave.md`

## Test plan

- [x] `mix test` — 314 tests, 0 failures
- [x] `mix credo --strict` — no issues
- [x] Manual: open soundboard web UI, click a sound while not in a voice channel — bot joins your channel and plays
- [x] Manual: leave the channel after playing — bot leaves immediately (`play` mode)
- [x] Manual: set `VOICE_IDLE_TIMEOUT_SECONDS=30`, play a sound, go quiet — bot leaves after 30 s
- [x] Manual: set `AUTO_JOIN=false`, `VOICE_IDLE_TIMEOUT_SECONDS=30`, use `!join`, have last user leave — bot leaves 30 s later; rejoin before timer fires → bot stays
- [x] Manual: set `AUTO_JOIN=presence` — bot follows you in and out as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)