### PR TITLE
Fix voice maintenance test flake

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -59,6 +59,8 @@ config :soundboard, :sql_sandbox, true
 
 config :soundboard, env: :test
 
+config :soundboard, Soundboard.AudioPlayer, voice_maintenance_enabled: false
+
 config :soundboard, Soundboard.PubSub,
   adapter: Phoenix.PubSub.PG2,
   name: Soundboard.PubSub

--- a/lib/soundboard/audio_player.ex
+++ b/lib/soundboard/audio_player.ex
@@ -321,6 +321,8 @@ defmodule Soundboard.AudioPlayer do
   end
 
   defp schedule_voice_check do
-    Process.send_after(self(), :check_voice_connection, 30_000)
+    if Application.get_env(:soundboard, __MODULE__, [])[:voice_maintenance_enabled] != false do
+      Process.send_after(self(), :check_voice_connection, 30_000)
+    end
   end
 end

--- a/lib/soundboard/audio_player/voice_session.ex
+++ b/lib/soundboard/audio_player/voice_session.ex
@@ -114,5 +114,7 @@ defmodule Soundboard.AudioPlayer.VoiceSession do
     :ok
   rescue
     error -> {:error, {:voice_join_failed, Exception.message(error)}}
+  catch
+    :exit, reason -> {:error, {:voice_join_failed, reason}}
   end
 end


### PR DESCRIPTION
## Summary
- disable automatic voice maintenance timers in test config
- keep explicit maintenance tests working via direct messages
- catch EDA voice join exits so AudioPlayer does not crash on join failures

## Verification
- mix test
