### PR TITLE
Fix voice reconnect recovery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@
 FROM elixir:1.20.0-otp-27-alpine AS build
 
 ARG MIX_ENV=prod
-ARG RUST_VERSION=1.96.0-r0
-ARG CARGO_VERSION=1.96.0-r0
 
 ENV MIX_ENV=$MIX_ENV \
     MIX_HOME=/app/.mix \
@@ -17,8 +15,8 @@ RUN echo "https://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositor
       git \
       make \
       build-base \
-      rust=${RUST_VERSION} \
-      cargo=${CARGO_VERSION}
+      rust \
+      cargo
 
 WORKDIR /app
 COPY --exclude=entrypoint.sh . .

--- a/lib/soundboard/application.ex
+++ b/lib/soundboard/application.ex
@@ -13,6 +13,7 @@ defmodule Soundboard.Application do
 
     children = [
       Soundboard.Repo,
+      {Task.Supervisor, name: Soundboard.AudioTaskSupervisor},
       {Soundboard.AudioPlayer, []},
       SoundboardWeb.Telemetry,
       {Phoenix.PubSub, name: Soundboard.PubSub},

--- a/lib/soundboard/audio_player/playback_queue.ex
+++ b/lib/soundboard/audio_player/playback_queue.ex
@@ -153,7 +153,7 @@ defmodule Soundboard.AudioPlayer.PlaybackQueue do
 
   defp start_playback(state, request) do
     task =
-      Task.async(fn ->
+      Task.Supervisor.async_nolink(Soundboard.AudioTaskSupervisor, fn ->
         PlaybackEngine.play(
           request.guild_id,
           request.channel_id,

--- a/lib/soundboard/audio_player/voice_session.ex
+++ b/lib/soundboard/audio_player/voice_session.ex
@@ -68,6 +68,18 @@ defmodule Soundboard.AudioPlayer.VoiceSession do
       "Voice session unready for guild #{status.guild_id} in channel #{status.channel_id}, forcing leave→rejoin"
     )
 
+    reset_voice_session(status, state)
+  end
+
+  defp perform_maintenance(status, state) do
+    Logger.warning(
+      "Voice channel mismatch for guild #{status.guild_id}, forcing leave→rejoin to #{status.channel_id}"
+    )
+
+    reset_voice_session(status, state)
+  end
+
+  defp reset_voice_session(status, state) do
     try do
       Voice.leave_channel(status.guild_id)
     rescue
@@ -76,14 +88,6 @@ defmodule Soundboard.AudioPlayer.VoiceSession do
 
     Process.sleep(1_000)
     attempt_voice_join(state, status.guild_id, status.channel_id, "rejoin after stale session")
-  end
-
-  defp perform_maintenance(status, state) do
-    Logger.warning(
-      "Voice channel mismatch for guild #{status.guild_id}, attempting to rejoin #{status.channel_id}"
-    )
-
-    attempt_voice_join(state, status.guild_id, status.channel_id, "rejoin")
   end
 
   defp attempt_voice_join(state, guild_id, channel_id, action) do

--- a/test/soundboard/audio_player/playback_queue_test.exs
+++ b/test/soundboard/audio_player/playback_queue_test.exs
@@ -136,6 +136,50 @@ defmodule Soundboard.AudioPlayer.PlaybackQueueTest do
     end
   end
 
+  test "cancelling an in-flight playback does not terminate its owner" do
+    test_pid = self()
+
+    with_mocks([
+      {Soundboard.Discord.Voice, [],
+       [
+         stop: fn "guild-1" -> :ok end,
+         playing?: fn "guild-1" -> false end
+       ]},
+      {Soundboard.AudioPlayer.PlaybackEngine, [],
+       [
+         play: fn "guild-1", "channel-9", "intro.mp3", "/tmp/intro.mp3", 0.8, "System" ->
+           send(test_pid, :playback_started)
+           Process.sleep(:infinity)
+         end
+       ]}
+    ]) do
+      owner =
+        spawn(fn ->
+          state = PlaybackQueue.enqueue(base_state(), request(), 35)
+          send(test_pid, {:playback_owner_ready, self(), state})
+
+          receive do
+            :cancel ->
+              PlaybackQueue.clear_all(state)
+              send(test_pid, :playback_owner_survived)
+              Process.sleep(:infinity)
+          end
+        end)
+
+      owner_ref = Process.monitor(owner)
+
+      assert_receive :playback_started
+      assert_receive {:playback_owner_ready, ^owner, _state}
+      send(owner, :cancel)
+
+      assert_receive :playback_owner_survived
+      refute_receive {:DOWN, ^owner_ref, :process, ^owner, _reason}
+
+      Process.exit(owner, :kill)
+      assert_receive {:DOWN, ^owner_ref, :process, ^owner, :killed}
+    end
+  end
+
   test "clear_all resets playback, pending, and interrupt state" do
     timer_ref = Process.send_after(self(), :unused_watchdog, 5_000)
 

--- a/test/soundboard_web/audio_player_test.exs
+++ b/test/soundboard_web/audio_player_test.exs
@@ -5,7 +5,7 @@ defmodule Soundboard.AudioPlayerTest do
 
   alias Soundboard.Accounts.User
   alias Soundboard.AudioPlayer
-  alias Soundboard.AudioPlayer.State
+  alias Soundboard.AudioPlayer.{State, VoiceSession}
   alias Soundboard.Discord.Handler.{AutoJoinPolicy, VoicePresence}
   alias Soundboard.Discord.Voice
 
@@ -17,6 +17,30 @@ defmodule Soundboard.AudioPlayerTest do
     end)
 
     :ok
+  end
+
+  test "forces leave and rejoin when EDA loses its channel after a gateway disconnect" do
+    test_pid = self()
+
+    state = %State{
+      voice_channel: {"guild-1", "channel-1"},
+      current_playback: nil,
+      pending_request: nil,
+      interrupting: false,
+      interrupt_watchdog_ref: nil,
+      interrupt_watchdog_attempt: 0
+    }
+
+    with_mock Voice,
+      channel_id: fn "guild-1" -> nil end,
+      ready?: fn "guild-1" -> false end,
+      playing?: fn "guild-1" -> false end,
+      leave_channel: fn "guild-1" -> send(test_pid, :left_channel) end,
+      join_channel: fn "guild-1", "channel-1" -> send(test_pid, :joined_channel) end do
+      assert VoiceSession.maintain_connection(state) == state
+      assert_received :left_channel
+      assert_received :joined_channel
+    end
   end
 
   test "continues voice maintenance when playback status is unavailable" do


### PR DESCRIPTION
## Summary
- force a full leave/rejoin when the cached Discord voice channel no longer matches EDA state
- run playback tasks under an unlinked task supervisor so cancellation cannot restart `AudioPlayer`
- add regression coverage for stale voice recovery and in-flight playback cancellation

## Root cause
After an EDA voice gateway `{:remote, :closed}`, Discord could still show the bot in-channel while EDA had cleared its voice token and endpoint. A soft join did not obtain fresh credentials. Rapid playback interruption could then kill the linked playback owner and lose the cached voice channel.

## Verification
- `mix test` — 340 tests passed
- `mix compile --warnings-as-errors`
- `mix credo --strict`