### PR TITLE
Add Tailwind-powered application themes

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -11,12 +11,57 @@
 .opacity-100 { opacity: 1; }
 
 :root {
-  background-color: rgb(17 24 39);
+  --color-canvas: 17 24 39;
+  --color-surface: 31 41 55;
+  --color-surface-raised: 55 65 81;
+  --color-surface-muted: 55 65 81;
+  --color-ink: 243 244 246;
+  --color-muted: 156 163 175;
+  --color-line: 75 85 99;
+  --color-accent: 37 99 235;
+  --color-accent-contrast: 255 255 255;
+  --font-theme: ui-sans-serif, system-ui, sans-serif;
+  --font-display: ui-sans-serif, system-ui, sans-serif;
+  --radius-theme: 0.5rem;
+  --shadow-theme: 0 8px 24px rgb(0 0 0 / 0.2);
+  background-color: rgb(var(--color-canvas));
   height: 100%;
 }
 
+[data-theme="desk"] {
+  --color-canvas: 199 195 184;
+  --color-surface: 231 228 218;
+  --color-surface-raised: 245 242 233;
+  --color-surface-muted: 216 212 201;
+  --color-ink: 19 20 22;
+  --color-muted: 84 82 77;
+  --color-line: 164 160 150;
+  --color-accent: 226 75 34;
+  --color-accent-contrast: 255 255 255;
+  --font-theme: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  --font-display: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  --radius-theme: 0.25rem;
+  --shadow-theme: 0 1px 0 rgb(255 255 255 / 0.9) inset, 0 3px 0 #a9a69d, 0 10px 24px rgb(19 20 22 / 0.14);
+}
+
+[data-theme="retro"] {
+  --color-canvas: 244 237 216;
+  --color-surface: 255 249 232;
+  --color-surface-raised: 255 253 244;
+  --color-surface-muted: 230 222 200;
+  --color-ink: 37 32 42;
+  --color-muted: 102 91 105;
+  --color-line: 37 32 42;
+  --color-accent: 33 79 198;
+  --color-accent-contrast: 255 249 232;
+  --font-theme: ui-sans-serif, system-ui, sans-serif;
+  --font-display: Georgia, Cambria, "Times New Roman", serif;
+  --radius-theme: 0.125rem;
+  --shadow-theme: 5px 5px 0 rgb(37 32 42 / 0.92);
+}
+
 html {
-  @apply bg-gray-900;
+  @apply bg-canvas;
   height: 100%;
   /* Hide scrollbar for Chrome, Safari and Opera */
   ::-webkit-scrollbar {
@@ -28,7 +73,7 @@ html {
 }
 
 body {
-  @apply bg-gray-900;
+  @apply bg-canvas text-ink font-theme transition-colors duration-200;
   min-height: 100%;
   padding-top: env(safe-area-inset-top);
   padding-bottom: env(safe-area-inset-bottom);
@@ -41,6 +86,15 @@ body {
   ::-webkit-scrollbar {
     display: none;
   }
+}
+
+[data-theme="desk"] body {
+  background-image: linear-gradient(rgb(255 255 255 / 0.12), rgb(0 0 0 / 0.035));
+}
+
+[data-theme="retro"] body {
+  background-image: radial-gradient(rgb(37 32 42 / 0.075) 0.7px, transparent 0.7px);
+  background-size: 5px 5px;
 }
 
 .loading-container {

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1,6 +1,9 @@
 @import "tailwindcss/base";
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
+@import "./themes/classic.css";
+@import "./themes/desk.css";
+@import "./themes/retro.css";
 
 .flash-message {
   opacity: 0;
@@ -11,53 +14,8 @@
 .opacity-100 { opacity: 1; }
 
 :root {
-  --color-canvas: 17 24 39;
-  --color-surface: 31 41 55;
-  --color-surface-raised: 55 65 81;
-  --color-surface-muted: 55 65 81;
-  --color-ink: 243 244 246;
-  --color-muted: 156 163 175;
-  --color-line: 75 85 99;
-  --color-accent: 37 99 235;
-  --color-accent-contrast: 255 255 255;
-  --font-theme: ui-sans-serif, system-ui, sans-serif;
-  --font-display: ui-sans-serif, system-ui, sans-serif;
-  --radius-theme: 0.5rem;
-  --shadow-theme: 0 8px 24px rgb(0 0 0 / 0.2);
   background-color: rgb(var(--color-canvas));
   height: 100%;
-}
-
-[data-theme="desk"] {
-  --color-canvas: 199 195 184;
-  --color-surface: 231 228 218;
-  --color-surface-raised: 245 242 233;
-  --color-surface-muted: 216 212 201;
-  --color-ink: 19 20 22;
-  --color-muted: 84 82 77;
-  --color-line: 164 160 150;
-  --color-accent: 226 75 34;
-  --color-accent-contrast: 255 255 255;
-  --font-theme: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  --font-display: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  --radius-theme: 0.25rem;
-  --shadow-theme: 0 1px 0 rgb(255 255 255 / 0.9) inset, 0 3px 0 #a9a69d, 0 10px 24px rgb(19 20 22 / 0.14);
-}
-
-[data-theme="retro"] {
-  --color-canvas: 244 237 216;
-  --color-surface: 255 249 232;
-  --color-surface-raised: 255 253 244;
-  --color-surface-muted: 230 222 200;
-  --color-ink: 37 32 42;
-  --color-muted: 102 91 105;
-  --color-line: 37 32 42;
-  --color-accent: 33 79 198;
-  --color-accent-contrast: 255 249 232;
-  --font-theme: ui-sans-serif, system-ui, sans-serif;
-  --font-display: Georgia, Cambria, "Times New Roman", serif;
-  --radius-theme: 0.125rem;
-  --shadow-theme: 5px 5px 0 rgb(37 32 42 / 0.92);
 }
 
 html {
@@ -86,15 +44,6 @@ body {
   ::-webkit-scrollbar {
     display: none;
   }
-}
-
-[data-theme="desk"] body {
-  background-image: linear-gradient(rgb(255 255 255 / 0.12), rgb(0 0 0 / 0.035));
-}
-
-[data-theme="retro"] body {
-  background-image: radial-gradient(rgb(37 32 42 / 0.075) 0.7px, transparent 0.7px);
-  background-size: 5px 5px;
 }
 
 .loading-container {

--- a/assets/css/themes/classic.css
+++ b/assets/css/themes/classic.css
@@ -9,6 +9,7 @@
   --color-line: 75 85 99;
   --color-accent: 37 99 235;
   --color-accent-contrast: 255 255 255;
+  --color-pop: 239 68 68;
   --font-theme: ui-sans-serif, system-ui, sans-serif;
   --font-display: ui-sans-serif, system-ui, sans-serif;
   --radius-theme: 0.5rem;

--- a/assets/css/themes/classic.css
+++ b/assets/css/themes/classic.css
@@ -15,3 +15,10 @@
   --radius-theme: 0.5rem;
   --shadow-theme: 0 8px 24px rgb(0 0 0 / 0.2);
 }
+
+[data-theme="classic"] .theme-toast {
+  @apply border-line bg-surface text-ink shadow-theme;
+}
+
+[data-theme="classic"] .theme-toast-info { @apply border-l-accent; }
+[data-theme="classic"] .theme-toast-error { @apply border-l-red-500; }

--- a/assets/css/themes/classic.css
+++ b/assets/css/themes/classic.css
@@ -1,0 +1,16 @@
+:root,
+[data-theme="classic"] {
+  --color-canvas: 17 24 39;
+  --color-surface: 31 41 55;
+  --color-surface-raised: 55 65 81;
+  --color-surface-muted: 55 65 81;
+  --color-ink: 243 244 246;
+  --color-muted: 156 163 175;
+  --color-line: 75 85 99;
+  --color-accent: 37 99 235;
+  --color-accent-contrast: 255 255 255;
+  --font-theme: ui-sans-serif, system-ui, sans-serif;
+  --font-display: ui-sans-serif, system-ui, sans-serif;
+  --radius-theme: 0.5rem;
+  --shadow-theme: 0 8px 24px rgb(0 0 0 / 0.2);
+}

--- a/assets/css/themes/desk.css
+++ b/assets/css/themes/desk.css
@@ -193,6 +193,34 @@
   @apply rounded-sm text-white/35 hover:text-white;
 }
 
+[data-theme="desk"] .theme-toast {
+  --toast-signal: 73 151 88;
+  @apply rounded-theme border border-line font-mono text-ink;
+  background: repeating-linear-gradient(90deg, rgb(255 255 255 / 0.42) 0 1px, transparent 1px 3px), linear-gradient(180deg, rgb(var(--color-surface-raised)), rgb(218 215 207));
+  box-shadow: 0 1px 0 rgb(255 255 255 / 0.9) inset, 0 3px 0 #a9a69d, 0 8px 18px rgb(0 0 0 / 0.22);
+}
+
+[data-theme="desk"] .theme-toast-error { --toast-signal: var(--color-accent); }
+
+[data-theme="desk"] .theme-toast::before {
+  content: "";
+  @apply absolute left-4 top-[21px] h-1.5 w-1.5 rounded-full;
+  background: rgb(var(--toast-signal));
+  box-shadow: 0 0 7px rgb(var(--toast-signal));
+}
+
+[data-theme="desk"] .theme-toast-title {
+  @apply pl-4 text-[10px] uppercase tracking-[0.16em];
+}
+
+[data-theme="desk"] .theme-toast-message {
+  @apply font-theme text-sm;
+}
+
+[data-theme="desk"] .theme-toast-close {
+  @apply text-muted hover:text-ink;
+}
+
 @media (min-width: 1024px) {
   [data-theme="desk"] .theme-sound-list { grid-template-columns: repeat(4, minmax(0, 1fr)); }
 }

--- a/assets/css/themes/desk.css
+++ b/assets/css/themes/desk.css
@@ -1,20 +1,205 @@
 [data-theme="desk"] {
-  --color-canvas: 199 195 184;
-  --color-surface: 231 228 218;
-  --color-surface-raised: 245 242 233;
-  --color-surface-muted: 216 212 201;
+  --color-canvas: 185 181 169;
+  --color-surface: 207 203 193;
+  --color-surface-raised: 243 241 235;
+  --color-surface-muted: 191 187 177;
   --color-ink: 19 20 22;
-  --color-muted: 84 82 77;
-  --color-line: 164 160 150;
-  --color-accent: 226 75 34;
+  --color-muted: 123 121 112;
+  --color-line: 174 170 160;
+  --color-accent: 240 60 18;
   --color-accent-contrast: 255 255 255;
-  --color-pop: 226 75 34;
-  --font-theme: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  --font-display: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  --radius-theme: 0.25rem;
-  --shadow-theme: 0 1px 0 rgb(255 255 255 / 0.9) inset, 0 3px 0 #a9a69d, 0 10px 24px rgb(19 20 22 / 0.14);
+  --color-pop: 240 60 18;
+  --font-theme: Arial, Helvetica, ui-sans-serif, system-ui, sans-serif;
+  --font-display: Arial, Helvetica, ui-sans-serif, system-ui, sans-serif;
+  --radius-theme: 3px;
+  --shadow-theme: 0 1px 0 rgb(255 255 255 / 0.5) inset, 0 18px 40px -18px rgb(0 0 0 / 0.45), 0 2px 0 rgb(0 0 0 / 0.12);
 }
 
 [data-theme="desk"] body {
-  background-image: linear-gradient(rgb(255 255 255 / 0.12), rgb(0 0 0 / 0.035));
+  @apply pb-28;
+  background-image: linear-gradient(rgb(255 255 255 / 0.1), rgb(0 0 0 / 0.035));
+}
+
+[data-theme="desk"] .theme-nav {
+  @apply border-line bg-surface text-ink shadow-theme;
+  background-image: repeating-linear-gradient(90deg, rgb(255 255 255 / 0.5) 0 1px, rgb(0 0 0 / 0.02) 1px 3px), linear-gradient(180deg, rgb(var(--color-surface-raised)), rgb(231 228 220));
+}
+
+[data-theme="desk"] .theme-nav::before,
+[data-theme="desk"] .theme-nav::after {
+  content: "";
+  @apply absolute top-2 h-[7px] w-[7px] rounded-full;
+  background: radial-gradient(circle at 35% 30%, #fff, #a9a69d);
+  box-shadow: 0 0 0 1px rgb(0 0 0 / 0.16) inset, 0 1px 0 rgb(255 255 255 / 0.7);
+}
+
+[data-theme="desk"] .theme-nav::before { @apply left-2; }
+[data-theme="desk"] .theme-nav::after { @apply right-2; }
+
+[data-theme="desk"] .theme-nav-inner {
+  @apply max-w-7xl;
+}
+
+[data-theme="desk"] .theme-brand {
+  @apply flex items-baseline gap-2 text-ink;
+  text-shadow: 0 1px 0 rgb(255 255 255 / 0.85);
+}
+
+[data-theme="desk"] .theme-brand-model {
+  @apply inline font-mono text-[9px] font-normal tracking-[0.22em] text-muted;
+}
+
+[data-theme="desk"] .theme-nav-link {
+  @apply my-3 h-10 rounded-theme border border-transparent px-3 pt-0 font-mono text-[11px] uppercase tracking-[0.14em] text-muted;
+}
+
+[data-theme="desk"] .theme-nav-link:hover {
+  @apply border-line bg-surface-raised/70 text-ink;
+}
+
+[data-theme="desk"] .theme-nav-link-active {
+  @apply border-line bg-surface-raised text-ink shadow-inner;
+}
+
+[data-theme="desk"] .theme-nav-link-active::before {
+  content: "";
+  @apply mr-2 inline-block h-[5px] w-[5px] rounded-full bg-accent align-middle shadow-[0_0_6px_rgb(var(--color-accent))];
+}
+
+[data-theme="desk"] .theme-page {
+  @apply my-6 grid max-w-7xl grid-cols-[minmax(220px,1fr)_auto] overflow-hidden rounded-md bg-surface px-0 py-0 shadow-theme;
+}
+
+[data-theme="desk"] .theme-page-heading {
+  @apply hidden;
+}
+
+[data-theme="desk"] .theme-page-header {
+  @apply col-start-2 row-start-1 mb-0 border-b border-line px-5 py-4;
+  background: linear-gradient(180deg, rgb(255 255 255 / 0.28), transparent);
+}
+
+[data-theme="desk"] .theme-actions {
+  @apply h-full w-auto flex-row items-center justify-end gap-2;
+}
+
+[data-theme="desk"] .theme-button {
+  @apply w-auto rounded-theme border border-line px-4 py-3 font-mono text-[11px] font-bold uppercase tracking-[0.12em] text-ink;
+  background: linear-gradient(180deg, rgb(var(--color-surface-raised)), rgb(218 215 207));
+  box-shadow: 0 1px 0 rgb(255 255 255 / 0.9) inset, 0 2px 0 #a9a69d, 0 3px 4px rgb(0 0 0 / 0.16);
+}
+
+[data-theme="desk"] .theme-button:hover {
+  @apply text-ink brightness-105;
+}
+
+[data-theme="desk"] .theme-button:active {
+  transform: translateY(2px);
+  box-shadow: 0 1px 2px rgb(0 0 0 / 0.25) inset;
+}
+
+[data-theme="desk"] .theme-button-primary {
+  @apply border-black bg-ink text-surface-raised;
+  background: linear-gradient(180deg, #26292b, #1c1e20);
+}
+
+[data-theme="desk"] .theme-button-pop {
+  @apply border-[#8e2409] bg-accent text-white;
+  background: linear-gradient(180deg, #f35a32, #d63410);
+}
+
+[data-theme="desk"] .theme-search-wrap {
+  @apply col-start-1 row-start-1 mb-0 border-b border-line px-5 py-4;
+  background: linear-gradient(180deg, rgb(255 255 255 / 0.28), transparent);
+}
+
+[data-theme="desk"] .theme-search {
+  @apply rounded-theme border-0 bg-surface-muted py-3 pl-9 font-mono text-xs tracking-[0.04em] shadow-inner focus:ring-2 focus:ring-accent;
+}
+
+[data-theme="desk"] .theme-tagbar {
+  @apply col-span-full mb-0 border-b border-line px-5 py-3;
+}
+
+[data-theme="desk"] .theme-tag-filter {
+  @apply rounded-full border border-line bg-surface-raised/40 px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.12em] text-muted;
+}
+
+[data-theme="desk"] .theme-tag-filter:hover {
+  @apply border-ink/30 text-ink;
+}
+
+[data-theme="desk"] .theme-tag-filter[aria-pressed="true"] {
+  @apply border-[#1c1e20] bg-[#1c1e20] text-surface-raised;
+}
+
+[data-theme="desk"] .theme-count {
+  @apply col-span-full mb-0 justify-end border-b border-line px-5 py-2 font-mono text-[10px] uppercase tracking-[0.12em];
+}
+
+[data-theme="desk"] .theme-sound-list {
+  @apply col-span-full grid-cols-2 gap-3.5 p-5;
+  background: radial-gradient(circle at 1px 1px, rgb(19 20 22 / 0.13) 1px, transparent 0) 0 0 / 9px 9px;
+}
+
+[data-theme="desk"] .theme-sound-card {
+  @apply flex flex-col rounded-[5px] border-0 bg-[#1c1e20] text-[#efede7] hover:translate-y-0;
+  aspect-ratio: 5 / 3;
+  background: linear-gradient(180deg, #2a2d30, #1c1e20);
+  box-shadow: 0 1px 0 rgb(255 255 255 / 0.13) inset, 0 -2px 3px rgb(0 0 0 / 0.4) inset, 0 4px 0 #8f8c84, 0 8px 14px rgb(0 0 0 / 0.3);
+}
+
+[data-theme="desk"] .theme-sound-card:hover {
+  background: linear-gradient(180deg, #33373a, #212426);
+}
+
+[data-theme="desk"] .theme-sound-card:active {
+  transform: translateY(4px);
+  box-shadow: 0 1px 0 rgb(255 255 255 / 0.1) inset, 0 -1px 2px rgb(0 0 0 / 0.5) inset, 0 3px 6px rgb(0 0 0 / 0.3);
+}
+
+[data-theme="desk"] .theme-sound-play:hover {
+  @apply bg-transparent;
+}
+
+[data-theme="desk"] .theme-sound-rank {
+  @apply relative z-10 mx-3 mt-3 block w-fit rounded-sm border border-white/20 px-1.5 py-0.5 font-mono text-[10px] leading-none text-white/55;
+}
+
+[data-theme="desk"] .theme-sound-content {
+  @apply min-h-0 flex-1 gap-2 p-3 pt-1;
+}
+
+[data-theme="desk"] .theme-sound-content::before {
+  content: "";
+  @apply my-auto block h-8 w-full opacity-50;
+  background: repeating-linear-gradient(90deg, #efede7 0 3px, transparent 3px 7px);
+  clip-path: polygon(0 45%, 5% 30%, 10% 55%, 15% 15%, 20% 65%, 25% 35%, 30% 72%, 35% 20%, 40% 60%, 45% 38%, 50% 80%, 55% 22%, 60% 58%, 65% 32%, 70% 68%, 75% 26%, 80% 54%, 85% 40%, 90% 62%, 95% 34%, 100% 48%, 100% 52%, 95% 66%, 90% 38%, 85% 60%, 80% 46%, 75% 74%, 70% 32%, 65% 68%, 60% 42%, 55% 78%, 50% 20%, 45% 62%, 40% 40%, 35% 80%, 30% 28%, 25% 65%, 20% 35%, 15% 85%, 10% 45%, 5% 70%, 0 55%);
+}
+
+[data-theme="desk"] .theme-sound-title {
+  @apply text-[15px] font-bold uppercase leading-tight tracking-[0.02em] text-[#efede7];
+}
+
+[data-theme="desk"] .theme-sound-meta {
+  @apply font-mono text-[9px] uppercase tracking-[0.08em] text-white/50;
+}
+
+[data-theme="desk"] .theme-sound-tag {
+  @apply rounded-sm bg-white/10 font-mono text-[9px] uppercase tracking-[0.1em] text-white/75;
+}
+
+[data-theme="desk"] .theme-icon-button {
+  @apply rounded-sm text-white/35 hover:text-white;
+}
+
+@media (min-width: 1024px) {
+  [data-theme="desk"] .theme-sound-list { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+}
+
+@media (max-width: 639px) {
+  [data-theme="desk"] .theme-page { @apply grid-cols-1; }
+  [data-theme="desk"] .theme-page-header,
+  [data-theme="desk"] .theme-search-wrap { @apply col-start-1 row-auto; }
+  [data-theme="desk"] .theme-actions { @apply flex-wrap justify-start; }
 }

--- a/assets/css/themes/desk.css
+++ b/assets/css/themes/desk.css
@@ -8,6 +8,7 @@
   --color-line: 164 160 150;
   --color-accent: 226 75 34;
   --color-accent-contrast: 255 255 255;
+  --color-pop: 226 75 34;
   --font-theme: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   --font-display: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   --radius-theme: 0.25rem;

--- a/assets/css/themes/desk.css
+++ b/assets/css/themes/desk.css
@@ -1,0 +1,19 @@
+[data-theme="desk"] {
+  --color-canvas: 199 195 184;
+  --color-surface: 231 228 218;
+  --color-surface-raised: 245 242 233;
+  --color-surface-muted: 216 212 201;
+  --color-ink: 19 20 22;
+  --color-muted: 84 82 77;
+  --color-line: 164 160 150;
+  --color-accent: 226 75 34;
+  --color-accent-contrast: 255 255 255;
+  --font-theme: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  --font-display: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  --radius-theme: 0.25rem;
+  --shadow-theme: 0 1px 0 rgb(255 255 255 / 0.9) inset, 0 3px 0 #a9a69d, 0 10px 24px rgb(19 20 22 / 0.14);
+}
+
+[data-theme="desk"] body {
+  background-image: linear-gradient(rgb(255 255 255 / 0.12), rgb(0 0 0 / 0.035));
+}

--- a/assets/css/themes/retro.css
+++ b/assets/css/themes/retro.css
@@ -1,0 +1,20 @@
+[data-theme="retro"] {
+  --color-canvas: 244 237 216;
+  --color-surface: 255 249 232;
+  --color-surface-raised: 255 253 244;
+  --color-surface-muted: 230 222 200;
+  --color-ink: 37 32 42;
+  --color-muted: 102 91 105;
+  --color-line: 37 32 42;
+  --color-accent: 33 79 198;
+  --color-accent-contrast: 255 249 232;
+  --font-theme: ui-sans-serif, system-ui, sans-serif;
+  --font-display: Georgia, Cambria, "Times New Roman", serif;
+  --radius-theme: 0.125rem;
+  --shadow-theme: 5px 5px 0 rgb(37 32 42 / 0.92);
+}
+
+[data-theme="retro"] body {
+  background-image: radial-gradient(rgb(37 32 42 / 0.075) 0.7px, transparent 0.7px);
+  background-size: 5px 5px;
+}

--- a/assets/css/themes/retro.css
+++ b/assets/css/themes/retro.css
@@ -32,12 +32,24 @@
   @apply uppercase not-italic tracking-[0.08em] text-canvas;
 }
 
+[data-theme="retro"] .theme-brand a,
+[data-theme="retro"] .theme-nav-link {
+  @apply transition-transform duration-100;
+}
+
 [data-theme="retro"] .theme-nav-link {
   @apply uppercase tracking-[0.16em] text-canvas/70;
 }
 
 [data-theme="retro"] .theme-nav-link-active {
   @apply border-pop text-canvas;
+}
+
+[data-theme="retro"] .theme-brand a:hover,
+[data-theme="retro"] .theme-nav-link:hover {
+  @apply border-pop text-pop;
+  transform: translate(-1px, -1px);
+  text-shadow: 2px 2px 0 rgb(var(--color-accent));
 }
 
 [data-theme="retro"] .theme-page {
@@ -110,15 +122,15 @@
 }
 
 [data-theme="retro"] .theme-sound-list {
-  @apply grid-cols-1 gap-0;
+  @apply gap-4 p-5;
 }
 
 [data-theme="retro"] .theme-sound-card {
-  @apply flex rounded-none border-0 border-b-2 border-line bg-transparent shadow-none hover:translate-y-0 hover:bg-pop;
+  @apply flex flex-col rounded-none border-2 border-line bg-transparent hover:-translate-y-1 hover:bg-pop;
 }
 
 [data-theme="retro"] .theme-sound-rank {
-  @apply relative z-10 block w-20 flex-none px-5 py-4 font-display text-4xl leading-none text-accent;
+  @apply relative z-10 block w-auto flex-none px-4 pb-0 pt-4 font-display text-4xl leading-none text-accent;
 }
 
 [data-theme="retro"] .theme-sound-card:hover .theme-sound-rank {
@@ -130,7 +142,7 @@
 }
 
 [data-theme="retro"] .theme-sound-content {
-  @apply min-h-0 flex-1 flex-row items-center gap-4 px-5 py-4;
+  @apply min-h-[150px] flex-1 flex-col items-stretch gap-3 px-4 py-4;
 }
 
 [data-theme="retro"] .theme-sound-title {

--- a/assets/css/themes/retro.css
+++ b/assets/css/themes/retro.css
@@ -1,20 +1,150 @@
 [data-theme="retro"] {
-  --color-canvas: 244 237 216;
-  --color-surface: 255 249 232;
-  --color-surface-raised: 255 253 244;
-  --color-surface-muted: 230 222 200;
-  --color-ink: 37 32 42;
-  --color-muted: 102 91 105;
-  --color-line: 37 32 42;
-  --color-accent: 33 79 198;
-  --color-accent-contrast: 255 249 232;
-  --font-theme: ui-sans-serif, system-ui, sans-serif;
-  --font-display: Georgia, Cambria, "Times New Roman", serif;
-  --radius-theme: 0.125rem;
-  --shadow-theme: 5px 5px 0 rgb(37 32 42 / 0.92);
+  --color-canvas: 237 235 225;
+  --color-surface: 247 245 235;
+  --color-surface-raised: 255 255 255;
+  --color-surface-muted: 216 213 200;
+  --color-ink: 18 18 18;
+  --color-muted: 82 80 75;
+  --color-line: 18 18 18;
+  --color-accent: 30 47 224;
+  --color-accent-contrast: 255 255 255;
+  --color-pop: 255 61 151;
+  --font-theme: "Arial Narrow", "Helvetica Neue", ui-sans-serif, system-ui, sans-serif;
+  --font-display: Impact, Haettenschweiler, "Arial Narrow Bold", sans-serif;
+  --radius-theme: 0;
+  --shadow-theme: 5px 5px 0 rgb(18 18 18 / 0.92);
 }
 
 [data-theme="retro"] body {
-  background-image: radial-gradient(rgb(37 32 42 / 0.075) 0.7px, transparent 0.7px);
-  background-size: 5px 5px;
+  background-image: radial-gradient(rgb(18 18 18 / 0.09) 0.5px, transparent 0.6px);
+  background-size: 3px 3px;
+}
+
+[data-theme="retro"] .theme-nav {
+  @apply border-0 bg-ink text-canvas shadow-none;
+}
+
+[data-theme="retro"] .theme-nav-inner {
+  @apply max-w-5xl;
+}
+
+[data-theme="retro"] .theme-brand {
+  @apply uppercase not-italic tracking-[0.08em] text-canvas;
+}
+
+[data-theme="retro"] .theme-nav-link {
+  @apply uppercase tracking-[0.16em] text-canvas/70;
+}
+
+[data-theme="retro"] .theme-nav-link-active {
+  @apply border-pop text-canvas;
+}
+
+[data-theme="retro"] .theme-page {
+  @apply my-6 max-w-5xl border-2 border-line bg-surface/30 px-0 py-0;
+}
+
+[data-theme="retro"] .theme-page-header {
+  @apply mb-0 border-b-2 border-line px-5 py-7;
+}
+
+[data-theme="retro"] .theme-eyebrow {
+  @apply mb-3 flex items-center gap-2 text-[11px] font-bold uppercase tracking-[0.24em] text-pop;
+}
+
+[data-theme="retro"] .theme-page-title {
+  @apply text-[clamp(3.5rem,10vw,7rem)] uppercase not-italic leading-[0.82] tracking-normal text-accent;
+}
+
+[data-theme="retro"] .theme-title-ghost {
+  @apply absolute inset-0 translate-x-1 translate-y-1 text-pop;
+  mix-blend-mode: multiply;
+}
+
+[data-theme="retro"] .theme-actions {
+  @apply w-full flex-row items-center justify-start gap-2 pt-5;
+}
+
+[data-theme="retro"] .theme-button {
+  @apply w-auto rounded-none border-2 border-line bg-canvas px-4 py-2 text-xs font-bold uppercase tracking-[0.14em] text-ink shadow-none;
+}
+
+[data-theme="retro"] .theme-button:hover {
+  @apply bg-ink text-canvas brightness-100;
+}
+
+[data-theme="retro"] .theme-button-primary {
+  @apply bg-accent text-white;
+}
+
+[data-theme="retro"] .theme-button-pop {
+  @apply bg-pop text-ink;
+}
+
+[data-theme="retro"] .theme-search-wrap {
+  @apply mb-0 border-b-2 border-line px-5 py-4;
+}
+
+[data-theme="retro"] .theme-search {
+  @apply rounded-none border-0 border-b-2 border-line bg-transparent pl-1 uppercase tracking-[0.08em] shadow-none;
+}
+
+[data-theme="retro"] .theme-tagbar {
+  @apply mb-0 border-b-2 border-line px-5 py-3;
+}
+
+[data-theme="retro"] .theme-tag-filter {
+  @apply rounded-full border-2 border-line bg-transparent px-3 py-1 text-[11px] font-bold uppercase tracking-[0.14em] text-ink;
+}
+
+[data-theme="retro"] .theme-tag-filter:hover {
+  @apply bg-ink text-canvas;
+}
+
+[data-theme="retro"] .theme-tag-filter[aria-pressed="true"] {
+  @apply border-accent bg-accent text-white;
+}
+
+[data-theme="retro"] .theme-count {
+  @apply mb-0 justify-end border-b-2 border-line px-5 py-2 text-[11px] uppercase tracking-[0.14em];
+}
+
+[data-theme="retro"] .theme-sound-list {
+  @apply grid-cols-1 gap-0;
+}
+
+[data-theme="retro"] .theme-sound-card {
+  @apply flex rounded-none border-0 border-b-2 border-line bg-transparent shadow-none hover:translate-y-0 hover:bg-pop;
+}
+
+[data-theme="retro"] .theme-sound-rank {
+  @apply relative z-10 block w-20 flex-none px-5 py-4 font-display text-4xl leading-none text-accent;
+}
+
+[data-theme="retro"] .theme-sound-card:hover .theme-sound-rank {
+  @apply text-ink;
+}
+
+[data-theme="retro"] .theme-sound-play:hover {
+  @apply bg-transparent;
+}
+
+[data-theme="retro"] .theme-sound-content {
+  @apply min-h-0 flex-1 flex-row items-center gap-4 px-5 py-4;
+}
+
+[data-theme="retro"] .theme-sound-title {
+  @apply text-xl font-bold uppercase leading-none tracking-tight;
+}
+
+[data-theme="retro"] .theme-sound-meta {
+  @apply mt-2 text-[10px] font-bold uppercase tracking-[0.14em] text-ink/70;
+}
+
+[data-theme="retro"] .theme-sound-tag {
+  @apply rounded-full border border-line bg-transparent text-ink;
+}
+
+[data-theme="retro"] .theme-icon-button {
+  @apply rounded-full text-ink/50 hover:text-ink;
 }

--- a/assets/css/themes/retro.css
+++ b/assets/css/themes/retro.css
@@ -160,3 +160,26 @@
 [data-theme="retro"] .theme-icon-button {
   @apply rounded-full text-ink/50 hover:text-ink;
 }
+
+[data-theme="retro"] .theme-toast {
+  @apply rounded-none border-2 border-line bg-canvas text-ink;
+  box-shadow: 5px 5px 0 rgb(var(--color-accent));
+  transform: rotate(-0.2deg);
+}
+
+[data-theme="retro"] .theme-toast-error {
+  @apply border-l-2 bg-pop;
+  box-shadow: 5px 5px 0 rgb(var(--color-ink));
+}
+
+[data-theme="retro"] .theme-toast-title {
+  @apply font-display text-lg uppercase leading-none tracking-[0.04em];
+}
+
+[data-theme="retro"] .theme-toast-message {
+  @apply border-t-2 border-line pt-2 font-bold uppercase tracking-[0.08em];
+}
+
+[data-theme="retro"] .theme-toast-close {
+  @apply text-ink hover:text-accent;
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -22,6 +22,38 @@ import {Socket} from "phoenix"
 import {LiveSocket} from "phoenix_live_view"
 import topbar from "../vendor/topbar"
 
+const THEMES = ["classic", "desk", "retro"]
+const THEME_COLORS = {classic: "#111827", desk: "#c7c3b8", retro: "#f4edd8"}
+
+const currentTheme = () => document.documentElement.dataset.theme || "classic"
+
+const syncThemeControls = () => {
+  const activeTheme = currentTheme()
+  document.querySelectorAll("[data-theme-choice]").forEach((button) => {
+    button.setAttribute("aria-pressed", button.dataset.themeChoice === activeTheme ? "true" : "false")
+  })
+}
+
+const setTheme = (theme, persist = true) => {
+  if (!THEMES.includes(theme)) return
+  document.documentElement.dataset.theme = theme
+  document.querySelector('meta[name="theme-color"]')?.setAttribute("content", THEME_COLORS[theme])
+  if (persist) localStorage.setItem("soundbored-theme", theme)
+  syncThemeControls()
+}
+
+document.addEventListener("click", (event) => {
+  const choice = event.target.closest("[data-theme-choice]")
+  if (choice) setTheme(choice.dataset.themeChoice)
+})
+
+window.addEventListener("storage", (event) => {
+  if (event.key === "soundbored-theme") setTheme(event.newValue, false)
+})
+
+window.addEventListener("phx:page-loading-stop", syncThemeControls)
+setTheme(currentTheme(), false)
+
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
 
 const clamp = (value, min, max) => Math.min(Math.max(value, min), max)

--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -6,6 +6,7 @@ const fs = require("fs")
 const path = require("path")
 
 module.exports = {
+  darkMode: ["class", '[data-theme="classic"]'],
   content: [
     "./js/**/*.js",
     "../lib/*_web/**/*.*ex"
@@ -14,6 +15,25 @@ module.exports = {
     extend: {
       colors: {
         brand: "#FD4F00",
+        canvas: "rgb(var(--color-canvas) / <alpha-value>)",
+        surface: "rgb(var(--color-surface) / <alpha-value>)",
+        "surface-raised": "rgb(var(--color-surface-raised) / <alpha-value>)",
+        "surface-muted": "rgb(var(--color-surface-muted) / <alpha-value>)",
+        ink: "rgb(var(--color-ink) / <alpha-value>)",
+        muted: "rgb(var(--color-muted) / <alpha-value>)",
+        line: "rgb(var(--color-line) / <alpha-value>)",
+        accent: "rgb(var(--color-accent) / <alpha-value>)",
+        "accent-contrast": "rgb(var(--color-accent-contrast) / <alpha-value>)",
+      },
+      fontFamily: {
+        theme: ["var(--font-theme)"],
+        display: ["var(--font-display)"],
+      },
+      borderRadius: {
+        theme: "var(--radius-theme)",
+      },
+      boxShadow: {
+        theme: "var(--shadow-theme)",
       },
       animation: {
         'fade-in': 'fadeIn 0.3s ease-in',
@@ -41,6 +61,11 @@ module.exports = {
     plugin(({addVariant}) => addVariant("phx-click-loading", [".phx-click-loading&", ".phx-click-loading &"])),
     plugin(({addVariant}) => addVariant("phx-submit-loading", [".phx-submit-loading&", ".phx-submit-loading &"])),
     plugin(({addVariant}) => addVariant("phx-change-loading", [".phx-change-loading&", ".phx-change-loading &"])),
+    plugin(({addVariant}) => {
+      addVariant("classic", '[data-theme="classic"] &')
+      addVariant("desk", '[data-theme="desk"] &')
+      addVariant("retro", '[data-theme="retro"] &')
+    }),
 
     // Embeds Heroicons (https://heroicons.com) into your app.css bundle
     // See your `CoreComponents.icon/1` for more information.

--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -24,6 +24,7 @@ module.exports = {
         line: "rgb(var(--color-line) / <alpha-value>)",
         accent: "rgb(var(--color-accent) / <alpha-value>)",
         "accent-contrast": "rgb(var(--color-accent-contrast) / <alpha-value>)",
+        pop: "rgb(var(--color-pop) / <alpha-value>)",
       },
       fontFamily: {
         theme: ["var(--font-theme)"],

--- a/lib/soundboard_web/components/core_components.ex
+++ b/lib/soundboard_web/components/core_components.ex
@@ -67,7 +67,7 @@ defmodule SoundboardWeb.CoreComponents do
               phx-window-keydown={JS.exec("data-cancel", to: "##{@id}")}
               phx-key="escape"
               phx-click-away={JS.exec("data-cancel", to: "##{@id}")}
-              class="shadow-zinc-700/10 ring-zinc-700/10 relative hidden rounded-2xl bg-white p-14 shadow-lg ring-1 transition"
+              class="relative hidden rounded-theme border border-line bg-surface p-14 text-ink shadow-theme transition"
             >
               <div class="absolute top-6 right-5">
                 <button
@@ -203,7 +203,7 @@ defmodule SoundboardWeb.CoreComponents do
   def simple_form(assigns) do
     ~H"""
     <.form :let={f} for={@for} as={@as} {@rest}>
-      <div class="mt-10 space-y-8 bg-white">
+      <div class="mt-10 space-y-8 bg-surface text-ink">
         {render_slot(@inner_block, f)}
         <div :for={action <- @actions} class="mt-2 flex items-center justify-between gap-6">
           {render_slot(action, f)}
@@ -336,7 +336,7 @@ defmodule SoundboardWeb.CoreComponents do
       <select
         id={@id}
         name={@name}
-        class="mt-2 block w-full rounded-md border border-gray-300 bg-white shadow-sm focus:border-zinc-400 focus:ring-0 sm:text-sm"
+        class="mt-2 block w-full rounded-theme border border-line bg-surface-muted text-ink shadow-sm focus:border-accent focus:ring-0 sm:text-sm"
         multiple={@multiple}
         {@rest}
       >

--- a/lib/soundboard_web/components/core_components.ex
+++ b/lib/soundboard_web/components/core_components.ex
@@ -116,19 +116,26 @@ defmodule SoundboardWeb.CoreComponents do
       phx-click={JS.push("lv:clear-flash", value: %{key: @kind}) |> hide("##{@id}")}
       role="alert"
       class={[
-        "fixed top-2 right-2 mr-2 w-80 sm:w-96 z-50 rounded-lg p-3 ring-1",
-        @kind == :info && "bg-emerald-50 text-emerald-800 ring-emerald-500 fill-cyan-900",
-        @kind == :error && "bg-rose-50 text-rose-900 shadow-md ring-rose-500 fill-rose-900"
+        "theme-toast fixed right-4 top-20 z-[60] w-[calc(100%-2rem)] max-w-96 rounded-theme border border-line bg-surface p-4 text-ink shadow-theme",
+        @kind == :info && "theme-toast-info border-l-4 border-l-accent fill-accent",
+        @kind == :error && "theme-toast-error border-l-4 border-l-red-500 fill-red-500"
       ]}
       {@rest}
     >
-      <p :if={@title} class="flex items-center gap-1.5 text-sm font-semibold leading-6">
+      <p
+        :if={@title}
+        class="theme-toast-title flex items-center gap-1.5 text-sm font-semibold leading-6"
+      >
         <.icon :if={@kind == :info} name="hero-information-circle-mini" class="h-4 w-4" />
         <.icon :if={@kind == :error} name="hero-exclamation-circle-mini" class="h-4 w-4" />
         {@title}
       </p>
-      <p class="mt-2 text-sm leading-5">{msg}</p>
-      <button type="button" class="group absolute top-1 right-1 p-2" aria-label={gettext("close")}>
+      <p class="theme-toast-message mt-2 text-sm leading-5">{msg}</p>
+      <button
+        type="button"
+        class="theme-toast-close group absolute right-1 top-1 p-2"
+        aria-label={gettext("close")}
+      >
         <.icon name="hero-x-mark-solid" class="h-5 w-5 opacity-40 group-hover:opacity-70" />
       </button>
     </div>

--- a/lib/soundboard_web/components/layouts/app.html.heex
+++ b/lib/soundboard_web/components/layouts/app.html.heex
@@ -8,7 +8,7 @@
   />
 </header>
 
-<main class="">
+<main class="min-h-[calc(100vh-4rem)] bg-canvas text-ink">
   <div>
     <.flash_group flash={@flash} />
     {@inner_content}

--- a/lib/soundboard_web/components/layouts/navbar.ex
+++ b/lib/soundboard_web/components/layouts/navbar.ex
@@ -17,12 +17,12 @@ defmodule SoundboardWeb.Components.Layouts.Navbar do
   @impl true
   def render(assigns) do
     ~H"""
-    <nav class="fixed w-full top-0 left-0 right-0 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 z-50">
+    <nav class="fixed inset-x-0 top-0 z-50 w-full border-b border-line bg-surface text-ink shadow-sm retro:shadow-theme">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex justify-between h-16">
           <div class="flex">
             <div class="flex-shrink-0 flex items-center">
-              <span class="text-xl font-bold text-gray-800 dark:text-white">
+              <span class="font-display text-xl font-bold text-ink desk:uppercase desk:tracking-[0.16em] retro:italic">
                 <.link navigate="/">SoundBored</.link>
               </span>
             </div>
@@ -48,7 +48,7 @@ defmodule SoundboardWeb.Components.Layouts.Navbar do
           </div>
 
           <div class="hidden sm:ml-6 sm:flex sm:items-center">
-            <div class="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
+            <div class="flex items-center gap-2 text-sm text-muted">
               <%= visible_users(@presences)
                   |> Enum.map(fn user -> %>
                 <div class="flex items-center gap-1">
@@ -76,7 +76,7 @@ defmodule SoundboardWeb.Components.Layouts.Navbar do
           <div class="-mr-2 flex items-center sm:hidden">
             <button
               type="button"
-              class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500"
+              class="inline-flex items-center justify-center rounded-theme p-2 text-muted hover:bg-surface-raised hover:text-ink focus:outline-none focus:ring-2 focus:ring-inset focus:ring-accent"
               aria-controls="mobile-menu"
               aria-expanded="false"
               phx-click="toggle-mobile-menu"
@@ -141,7 +141,7 @@ defmodule SoundboardWeb.Components.Layouts.Navbar do
             </.mobile_nav_link>
           <% end %>
         </div>
-        <div class="pt-4 pb-3 border-t border-gray-200 dark:border-gray-700">
+        <div class="border-t border-line pb-3 pt-4">
           <div class="space-y-2 px-4">
             <%= visible_users(@presences)
                 |> Enum.map(fn user -> %>
@@ -176,11 +176,10 @@ defmodule SoundboardWeb.Components.Layouts.Navbar do
     <.link
       navigate={@navigate}
       class={[
-        "inline-flex items-center px-1 pt-1 text-sm font-medium",
+        "inline-flex items-center px-1 pt-1 text-sm font-medium desk:uppercase desk:tracking-[0.1em]",
         if(@active,
-          do: "border-b-2 border-blue-500 text-gray-900 dark:text-gray-100",
-          else:
-            "border-b-2 border-transparent text-gray-500 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-700 dark:hover:text-gray-200"
+          do: "border-b-2 border-accent text-ink",
+          else: "border-b-2 border-transparent text-muted hover:border-line hover:text-ink"
         )
       ]}
     >
@@ -196,9 +195,9 @@ defmodule SoundboardWeb.Components.Layouts.Navbar do
       class={[
         "block pl-4 pr-4 py-3 border-l-4 text-base font-medium leading-relaxed tracking-wide",
         if(@active,
-          do: "bg-blue-50 dark:bg-blue-900/50 border-blue-500 text-blue-700 dark:text-blue-100",
+          do: "border-accent bg-surface-raised text-ink",
           else:
-            "border-transparent text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-800 dark:hover:text-gray-200"
+            "border-transparent text-muted hover:border-line hover:bg-surface-muted hover:text-ink"
         )
       ]}
     >

--- a/lib/soundboard_web/components/layouts/navbar.ex
+++ b/lib/soundboard_web/components/layouts/navbar.ex
@@ -17,12 +17,12 @@ defmodule SoundboardWeb.Components.Layouts.Navbar do
   @impl true
   def render(assigns) do
     ~H"""
-    <nav class="fixed inset-x-0 top-0 z-50 w-full border-b border-line bg-surface text-ink shadow-sm retro:shadow-theme">
-      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <nav class="theme-nav fixed inset-x-0 top-0 z-50 w-full border-b border-line bg-surface text-ink shadow-sm">
+      <div class="theme-nav-inner max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex justify-between h-16">
           <div class="flex">
             <div class="flex-shrink-0 flex items-center">
-              <span class="font-display text-xl font-bold text-ink desk:uppercase desk:tracking-[0.16em] retro:italic">
+              <span class="theme-brand font-display text-xl font-bold text-ink desk:uppercase desk:tracking-[0.16em]">
                 <.link navigate="/">SoundBored</.link>
               </span>
             </div>
@@ -176,9 +176,9 @@ defmodule SoundboardWeb.Components.Layouts.Navbar do
     <.link
       navigate={@navigate}
       class={[
-        "inline-flex items-center px-1 pt-1 text-sm font-medium desk:uppercase desk:tracking-[0.1em]",
+        "theme-nav-link inline-flex items-center px-1 pt-1 text-sm font-medium desk:uppercase desk:tracking-[0.1em]",
         if(@active,
-          do: "border-b-2 border-accent text-ink",
+          do: "theme-nav-link-active border-b-2 border-accent text-ink",
           else: "border-b-2 border-transparent text-muted hover:border-line hover:text-ink"
         )
       ]}

--- a/lib/soundboard_web/components/layouts/navbar.ex
+++ b/lib/soundboard_web/components/layouts/navbar.ex
@@ -24,6 +24,7 @@ defmodule SoundboardWeb.Components.Layouts.Navbar do
             <div class="flex-shrink-0 flex items-center">
               <span class="theme-brand font-display text-xl font-bold text-ink desk:uppercase desk:tracking-[0.16em]">
                 <.link navigate="/">SoundBored</.link>
+                <span class="theme-brand-model hidden">MK II</span>
               </span>
             </div>
             <div class="hidden sm:ml-6 sm:flex sm:space-x-8">

--- a/lib/soundboard_web/components/layouts/root.html.heex
+++ b/lib/soundboard_web/components/layouts/root.html.heex
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="[scrollbar-gutter:stable]">
+<html lang="en" data-theme="classic" class="[scrollbar-gutter:stable]">
   <head>
     <meta charset="utf-8" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
@@ -13,6 +13,13 @@
     <meta name="apple-mobile-web-app-title" content="SoundBored" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-touch-fullscreen" content="yes" />
+    <script>
+      (() => {
+        const allowed = ["classic", "desk", "retro"]
+        const saved = localStorage.getItem("soundbored-theme")
+        document.documentElement.dataset.theme = allowed.includes(saved) ? saved : "classic"
+      })()
+    </script>
 
     <link rel="apple-touch-icon" href={~p"/images/icon-192.png"} />
     <.live_title suffix="">
@@ -22,7 +29,7 @@
     <script defer phx-track-static type="text/javascript" src={~p"/assets/app.js"}>
     </script>
   </head>
-  <body class="antialiased bg-gray-900">
+  <body class="antialiased bg-canvas text-ink font-theme">
     {@inner_content}
   </body>
 </html>

--- a/lib/soundboard_web/components/soundboard/tag_components.ex
+++ b/lib/soundboard_web/components/soundboard/tag_components.ex
@@ -84,8 +84,9 @@ defmodule SoundboardWeb.Components.Soundboard.TagComponents do
     <button
       phx-click={@click_event}
       phx-value-tag={tag_value(@tag, @tag_key)}
+      aria-pressed={LiveTags.tag_selected?(@tag, @selected_tags)}
       class={[
-        "inline-flex items-center gap-1 rounded-full px-3 py-1 text-sm font-medium",
+        "theme-tag-filter inline-flex items-center gap-1 rounded-full px-3 py-1 text-sm font-medium",
         if(LiveTags.tag_selected?(@tag, @selected_tags),
           do: "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300",
           else:

--- a/lib/soundboard_web/live/favorites_live.html.heex
+++ b/lib/soundboard_web/live/favorites_live.html.heex
@@ -1,7 +1,9 @@
-<div class="max-w-6xl mx-auto px-4 py-8">
+<div class="mx-auto max-w-6xl px-4 py-8 text-ink">
   <div class="flex justify-between items-center mb-8">
-    <h1 class="text-3xl font-bold text-gray-800 dark:text-gray-100">Favorites</h1>
-    <div class="text-sm text-gray-600 dark:text-gray-400">
+    <h1 class="font-display text-3xl font-bold text-ink desk:uppercase desk:tracking-[0.14em] retro:italic">
+      Favorites
+    </h1>
+    <div class="text-sm text-muted">
       {length(@favorites)}/{@max_favorites} favorites
     </div>
   </div>
@@ -10,17 +12,17 @@
     <%= if @sounds_with_tags == [] do %>
       <div class="flex flex-col items-center justify-center py-16">
         <div class="text-6xl mb-4">😢</div>
-        <h3 class="text-xl font-medium text-gray-900 dark:text-gray-100 mb-2">
+        <h3 class="text-xl font-medium text-ink mb-2">
           You currently have no favorites
         </h3>
-        <p class="text-gray-500 dark:text-gray-400">
+        <p class="text-muted">
           Click the heart icon on any sound to add it to your favorites
         </p>
       </div>
     <% else %>
       <div class="grid grid-cols-1 sm:grid-cols-3 lg:grid-cols-4 gap-4">
         <%= for sound <- @sounds_with_tags do %>
-          <div class="relative bg-white dark:bg-gray-800 rounded-lg shadow hover:shadow-md transition-all duration-200">
+          <div class="relative rounded-theme border border-line bg-surface shadow-theme transition-all duration-200 hover:-translate-y-0.5">
             <button
               phx-click="play"
               phx-value-name={sound.filename}
@@ -32,7 +34,7 @@
             </button>
 
             <div class="relative z-10 p-4 flex flex-col min-h-[120px] pointer-events-none">
-              <div class="text-gray-800 dark:text-gray-200 font-medium break-all">
+              <div class="text-ink font-medium break-all">
                 {display_name(sound.filename)}
               </div>
 
@@ -40,7 +42,7 @@
                 <div class="flex flex-wrap gap-1 items-center">
                   <%= if sound.tags != [] do %>
                     <%= for tag <- sound.tags do %>
-                      <span class="inline-flex items-center rounded-full bg-blue-50 dark:bg-blue-900 px-2 py-1 text-xs font-medium text-blue-600 dark:text-blue-300">
+                      <span class="inline-flex items-center rounded-full bg-accent/10 px-2 py-1 text-xs font-medium text-accent">
                         {tag.name}
                       </span>
                     <% end %>
@@ -105,7 +107,7 @@
     <% end %>
   <% else %>
     <div class="text-center py-12">
-      <p class="text-gray-600 dark:text-gray-400">
+      <p class="text-muted">
         Please log in to manage your favorites
       </p>
     </div>

--- a/lib/soundboard_web/live/settings_live.ex
+++ b/lib/soundboard_web/live/settings_live.ex
@@ -64,34 +64,89 @@ defmodule SoundboardWeb.SettingsLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <div class="max-w-6xl mx-auto px-4 py-6 space-y-6">
-      <h1 class="text-2xl font-bold text-gray-800 dark:text-gray-100">Settings</h1>
+    <div class="mx-auto max-w-6xl space-y-8 px-4 py-8">
+      <h1 class="font-display text-3xl font-bold text-ink desk:uppercase desk:tracking-[0.14em] retro:italic">
+        Settings
+      </h1>
+
+      <section aria-labelledby="appearance-heading" class="space-y-4">
+        <header class="space-y-1">
+          <h2 id="appearance-heading" class="font-display text-xl font-semibold text-ink">
+            Appearance
+          </h2>
+          <p class="text-sm text-muted">Choose a theme. Your selection stays in this browser.</p>
+        </header>
+
+        <div class="grid gap-4 sm:grid-cols-3" id="theme-picker">
+          <button
+            type="button"
+            data-theme-choice="classic"
+            aria-pressed="false"
+            class="group rounded-theme border border-line bg-surface p-4 text-left shadow-theme transition hover:-translate-y-0.5 classic:ring-2 classic:ring-accent"
+          >
+            <span class="mb-3 block h-16 rounded bg-gray-900 p-3 shadow-inner">
+              <i class="block h-2 w-2/3 rounded bg-blue-500"></i>
+              <i class="mt-2 block h-5 rounded bg-gray-700"></i>
+            </span>
+            <strong class="block text-ink">Classic</strong>
+            <small class="text-muted">Clean, dark, and familiar</small>
+          </button>
+
+          <button
+            type="button"
+            data-theme-choice="desk"
+            aria-pressed="false"
+            class="group rounded-theme border border-line bg-surface p-4 text-left shadow-theme transition hover:-translate-y-0.5 desk:ring-2 desk:ring-accent"
+          >
+            <span class="mb-3 block h-16 rounded-sm border border-stone-500 bg-stone-300 p-3 shadow-inner">
+              <i class="block h-2 w-2/3 bg-orange-600"></i>
+              <i class="mt-2 block h-5 border border-stone-500 bg-stone-200"></i>
+            </span>
+            <strong class="block text-ink">Studio Desk</strong>
+            <small class="text-muted">Warm hardware and signal orange</small>
+          </button>
+
+          <button
+            type="button"
+            data-theme-choice="retro"
+            aria-pressed="false"
+            class="group rounded-theme border border-line bg-surface p-4 text-left shadow-theme transition hover:-translate-y-0.5 retro:ring-2 retro:ring-accent"
+          >
+            <span class="mb-3 block h-16 border-2 border-slate-900 bg-amber-50 p-3 shadow-[3px_3px_0_#25202a]">
+              <i class="block h-2 w-2/3 bg-blue-700"></i>
+              <i class="mt-2 block h-5 border-2 border-slate-900 bg-red-500"></i>
+            </span>
+            <strong class="block text-ink">Retro Riso</strong>
+            <small class="text-muted">Paper, ink, and punchy print color</small>
+          </button>
+        </div>
+      </section>
 
       <section aria-labelledby="api-tokens-heading" class="space-y-6">
         <header class="space-y-2">
-          <h2 id="api-tokens-heading" class="text-xl font-semibold text-gray-800 dark:text-gray-100">
+          <h2 id="api-tokens-heading" class="font-display text-xl font-semibold text-ink">
             API Tokens
           </h2>
-          <p class="text-sm text-gray-600 dark:text-gray-400">
+          <p class="text-sm text-muted">
             Create a personal token to play sounds remotely. Requests authenticated with a token
             are attributed to your account and update your stats.
           </p>
         </header>
 
-        <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-5 space-y-4">
+        <div class="bg-surface rounded-theme border border-line shadow-theme p-5 space-y-4">
           <form phx-submit="create_token" class="flex flex-col gap-3 sm:flex-row sm:items-end">
             <div class="flex-1">
-              <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Label</label>
+              <label class="block text-sm font-medium text-ink">Label</label>
               <input
                 name="label"
                 type="text"
                 placeholder="e.g., CI Bot"
-                class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-700 shadow-sm dark:bg-gray-900 dark:text-gray-100 focus:border-blue-500 focus:ring-blue-500"
+                class="mt-1 block w-full rounded-theme border-line bg-surface-muted text-ink shadow-sm placeholder:text-muted focus:border-accent focus:ring-accent"
               />
             </div>
             <button
               type="submit"
-              class="w-full sm:w-auto justify-center px-4 py-2 bg-blue-600 text-white rounded-md font-medium hover:bg-blue-700 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 flex items-center"
+              class="w-full sm:w-auto justify-center px-4 py-2 bg-accent text-accent-contrast rounded-md font-medium hover:brightness-110 transition-colors focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 dark:focus:ring-offset-gray-900 flex items-center"
             >
               Create
             </button>
@@ -118,38 +173,38 @@ defmodule SoundboardWeb.SettingsLive do
               >
                 Copy
               </button>
-              <pre class="p-2 pr-20 bg-white dark:bg-gray-900 border border-green-300 dark:border-green-700 rounded text-xs overflow-x-auto whitespace-nowrap"><code class="text-gray-800 dark:text-gray-100 font-mono">{@new_token}</code></pre>
+              <pre class="overflow-x-auto whitespace-nowrap rounded-theme border border-line bg-surface-muted p-2 pr-20 text-xs"><code class="font-mono text-ink">{@new_token}</code></pre>
             </div>
           </div>
         <% end %>
 
-        <div class="bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden">
+        <div class="bg-surface rounded-theme border border-line shadow-theme overflow-hidden">
           <div class="overflow-x-auto">
-            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
-              <thead class="bg-gray-50 dark:bg-gray-900">
+            <table class="min-w-full divide-y divide-line text-sm">
+              <thead class="bg-surface-muted">
                 <tr>
-                  <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th class="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-muted">
                     Label
                   </th>
-                  <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th class="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-muted">
                     Created
                   </th>
-                  <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th class="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-muted">
                     Last Used
                   </th>
                   <th class="px-4 py-2"></th>
                 </tr>
               </thead>
-              <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+              <tbody class="divide-y divide-line">
                 <%= for token <- @tokens do %>
                   <tr class="text-sm">
-                    <td class="px-4 py-2 text-gray-900 dark:text-gray-100 whitespace-nowrap">
+                    <td class="px-4 py-2 text-ink whitespace-nowrap">
                       {token.label || "(no label)"}
                     </td>
-                    <td class="px-4 py-2 text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                    <td class="px-4 py-2 text-muted whitespace-nowrap">
                       {format_dt(token.inserted_at)}
                     </td>
-                    <td class="px-4 py-2 text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                    <td class="px-4 py-2 text-muted whitespace-nowrap">
                       {format_dt(token.last_used_at) || "—"}
                     </td>
                     <td class="px-4 py-2 text-right align-top">
@@ -168,31 +223,31 @@ defmodule SoundboardWeb.SettingsLive do
           </div>
         </div>
 
-        <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-5 space-y-4">
-          <h3 class="text-lg font-semibold text-gray-800 dark:text-gray-100">How to call the API</h3>
-          <p class="text-sm text-gray-700 dark:text-gray-300">
+        <div class="bg-surface rounded-theme border border-line shadow-theme p-5 space-y-4">
+          <h3 class="text-lg font-semibold text-ink">How to call the API</h3>
+          <p class="text-sm text-ink">
             Include your token in the Authorization header:
-            <code class="px-1 py-0.5 rounded bg-gray-100 dark:bg-gray-800 text-gray-800 dark:text-gray-100 font-mono">
+            <code class="rounded bg-surface-muted px-1 py-0.5 font-mono text-ink">
               Authorization: Bearer {@example_token || "<token>"}
             </code>
           </p>
           <div class="space-y-4">
             <div>
-              <div class="text-sm font-medium text-gray-700 dark:text-gray-300">List sounds</div>
+              <div class="text-sm font-medium text-ink">List sounds</div>
               <div class="relative">
                 <button
                   id="copy-list-sounds"
                   type="button"
                   phx-hook="CopyButton"
                   data-copy-text={"curl -H \"Authorization: Bearer #{(@example_token || "<TOKEN>")}\" #{@base_url}/api/sounds"}
-                  class="absolute right-2 top-2 text-xs px-2 py-1 bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-100 rounded"
+                  class="absolute right-2 top-2 text-xs px-2 py-1 bg-surface-muted hover:bg-surface-raised text-ink rounded"
                 >
                   Copy
                 </button>
-                <pre class="mt-1 p-2 pr-16 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded text-xs overflow-x-auto whitespace-nowrap min-h-[56px]"><code class="text-gray-800 dark:text-gray-100 font-mono">curl -H \"Authorization: Bearer {(@example_token || "<TOKEN>")}\" {@base_url}/api/sounds</code></pre>
+                <pre class="mt-1 p-2 pr-16 bg-surface-muted border border-line rounded text-xs overflow-x-auto whitespace-nowrap min-h-[56px]"><code class="text-ink font-mono">curl -H \"Authorization: Bearer {(@example_token || "<TOKEN>")}\" {@base_url}/api/sounds</code></pre>
               </div>
             </div>
-            <div class="text-xs text-gray-600 dark:text-gray-400">
+            <div class="text-xs text-muted">
               Upload endpoint: <code class="font-mono">POST /api/sounds</code>. Required fields:
               <code class="font-mono">name</code>
               plus either <code class="font-mono">file</code>
@@ -203,7 +258,7 @@ defmodule SoundboardWeb.SettingsLive do
               (0-150), <code class="font-mono">is_join_sound</code>, <code class="font-mono">is_leave_sound</code>.
             </div>
             <div>
-              <div class="text-sm font-medium text-gray-700 dark:text-gray-300">
+              <div class="text-sm font-medium text-ink">
                 Upload local file (multipart/form-data)
               </div>
               <div class="relative">
@@ -212,11 +267,11 @@ defmodule SoundboardWeb.SettingsLive do
                   type="button"
                   phx-hook="CopyButton"
                   data-copy-text={"curl -X POST -H \"Authorization: Bearer #{(@example_token || "<TOKEN>")}\" -F \"source_type=local\" -F \"name=<NAME>\" -F \"file=@/path/to/sound.mp3\" -F \"tags[]=meme\" -F \"tags[]=alert\" -F \"volume=90\" -F \"is_join_sound=true\" #{@base_url}/api/sounds"}
-                  class="absolute right-2 top-2 text-xs px-2 py-1 bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-100 rounded"
+                  class="absolute right-2 top-2 text-xs px-2 py-1 bg-surface-muted hover:bg-surface-raised text-ink rounded"
                 >
                   Copy
                 </button>
-                <pre class="mt-1 p-2 pr-16 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded text-xs overflow-x-auto min-h-[120px]"><code class="text-gray-800 dark:text-gray-100 font-mono">curl -X POST \
+                <pre class="mt-1 p-2 pr-16 bg-surface-muted border border-line rounded text-xs overflow-x-auto min-h-[120px]"><code class="text-ink font-mono">curl -X POST \
     -H "Authorization: Bearer {(@example_token || "<TOKEN>")}" \
     -F "source_type=local" \
     -F "name=&lt;NAME&gt;" \
@@ -229,7 +284,7 @@ defmodule SoundboardWeb.SettingsLive do
               </div>
             </div>
             <div>
-              <div class="text-sm font-medium text-gray-700 dark:text-gray-300">
+              <div class="text-sm font-medium text-ink">
                 Upload from URL (JSON)
               </div>
               <div class="relative">
@@ -238,11 +293,11 @@ defmodule SoundboardWeb.SettingsLive do
                   type="button"
                   phx-hook="CopyButton"
                   data-copy-text={"curl -X POST -H \"Authorization: Bearer #{(@example_token || "<TOKEN>")}\" -H \"Content-Type: application/json\" -d '{\"source_type\":\"url\",\"name\":\"wow\",\"url\":\"https://example.com/wow.mp3\",\"tags\":[\"meme\",\"reaction\"],\"volume\":90,\"is_leave_sound\":true}' #{@base_url}/api/sounds"}
-                  class="absolute right-2 top-2 text-xs px-2 py-1 bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-100 rounded"
+                  class="absolute right-2 top-2 text-xs px-2 py-1 bg-surface-muted hover:bg-surface-raised text-ink rounded"
                 >
                   Copy
                 </button>
-                <pre class="mt-1 p-2 pr-16 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded text-xs overflow-x-auto min-h-[110px]"><code class="text-gray-800 dark:text-gray-100 font-mono">curl -X POST \
+                <pre class="mt-1 p-2 pr-16 bg-surface-muted border border-line rounded text-xs overflow-x-auto min-h-[110px]"><code class="text-ink font-mono">curl -X POST \
     -H "Authorization: Bearer {(@example_token || "<TOKEN>")}" \
     -H "Content-Type: application/json" \
     -d '&#123;"source_type":"url","name":"wow","url":"https://example.com/wow.mp3","tags":["meme","reaction"],"volume":90,"is_leave_sound":true&#125;' \
@@ -250,7 +305,7 @@ defmodule SoundboardWeb.SettingsLive do
               </div>
             </div>
             <div>
-              <div class="text-sm font-medium text-gray-700 dark:text-gray-300">
+              <div class="text-sm font-medium text-ink">
                 Play a sound by ID
               </div>
               <div class="relative">
@@ -259,26 +314,26 @@ defmodule SoundboardWeb.SettingsLive do
                   type="button"
                   phx-hook="CopyButton"
                   data-copy-text={"curl -X POST -H \"Authorization: Bearer #{(@example_token || "<TOKEN>")}\" #{@base_url}/api/sounds/<SOUND_ID>/play"}
-                  class="absolute right-2 top-2 text-xs px-2 py-1 bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-100 rounded"
+                  class="absolute right-2 top-2 text-xs px-2 py-1 bg-surface-muted hover:bg-surface-raised text-ink rounded"
                 >
                   Copy
                 </button>
-                <pre class="mt-1 p-2 pr-16 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded text-xs overflow-x-auto whitespace-nowrap min-h-[56px]"><code class="text-gray-800 dark:text-gray-100 font-mono">curl -X POST -H \"Authorization: Bearer {(@example_token || "<TOKEN>")}\" {@base_url}/api/sounds/&lt;SOUND_ID&gt;/play</code></pre>
+                <pre class="mt-1 p-2 pr-16 bg-surface-muted border border-line rounded text-xs overflow-x-auto whitespace-nowrap min-h-[56px]"><code class="text-ink font-mono">curl -X POST -H \"Authorization: Bearer {(@example_token || "<TOKEN>")}\" {@base_url}/api/sounds/&lt;SOUND_ID&gt;/play</code></pre>
               </div>
             </div>
             <div>
-              <div class="text-sm font-medium text-gray-700 dark:text-gray-300">Stop all sounds</div>
+              <div class="text-sm font-medium text-ink">Stop all sounds</div>
               <div class="relative">
                 <button
                   id="copy-stop-sounds"
                   type="button"
                   phx-hook="CopyButton"
                   data-copy-text={"curl -X POST -H \"Authorization: Bearer #{(@example_token || "<TOKEN>")}\" #{@base_url}/api/sounds/stop"}
-                  class="absolute right-2 top-2 text-xs px-2 py-1 bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-100 rounded"
+                  class="absolute right-2 top-2 text-xs px-2 py-1 bg-surface-muted hover:bg-surface-raised text-ink rounded"
                 >
                   Copy
                 </button>
-                <pre class="mt-1 p-2 pr-16 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded text-xs overflow-x-auto whitespace-nowrap min-h-[56px]"><code class="text-gray-800 dark:text-gray-100 font-mono">curl -X POST -H \"Authorization: Bearer {(@example_token || "<TOKEN>")}\" {@base_url}/api/sounds/stop</code></pre>
+                <pre class="mt-1 p-2 pr-16 bg-surface-muted border border-line rounded text-xs overflow-x-auto whitespace-nowrap min-h-[56px]"><code class="text-ink font-mono">curl -X POST -H \"Authorization: Bearer {(@example_token || "<TOKEN>")}\" {@base_url}/api/sounds/stop</code></pre>
               </div>
             </div>
           </div>

--- a/lib/soundboard_web/live/soundboard_live.html.heex
+++ b/lib/soundboard_web/live/soundboard_live.html.heex
@@ -1,6 +1,6 @@
-<div class="max-w-6xl mx-auto px-4 py-8">
+<div class="mx-auto max-w-6xl px-4 py-8 text-ink">
   <div class="flex flex-wrap items-start justify-between gap-4 mb-8">
-    <h1 class="text-3xl font-bold text-gray-800 dark:text-gray-100 flex-1 min-w-[200px]">
+    <h1 class="min-w-[200px] flex-1 font-display text-3xl font-bold text-ink desk:uppercase desk:tracking-[0.14em] retro:italic">
       <span class="group relative cursor-default inline-block">
         Sounds<div class="pointer-events-none fixed inset-0 opacity-0 group-hover:opacity-100 transition-all duration-300 z-[9999]">
           <img
@@ -14,8 +14,8 @@
     <div class="flex flex-col sm:flex-row sm:flex-wrap sm:items-center sm:justify-end gap-2 w-full sm:w-auto">
       <button
         phx-click="show_upload_modal"
-        class="w-full sm:w-auto justify-center px-3 py-2 sm:px-4 sm:py-2 bg-blue-600 text-white font-medium rounded-md
-               hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors
+        class="w-full sm:w-auto justify-center px-3 py-2 sm:px-4 sm:py-2 bg-accent text-accent-contrast font-medium rounded-md
+               hover:brightness-110 focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 transition-colors
                dark:focus:ring-offset-gray-900 text-sm sm:text-base"
       >
         Add Sound
@@ -23,7 +23,7 @@
       <button
         phx-click="play_random"
         class="w-full sm:w-auto justify-center px-3 py-2 sm:px-4 sm:py-2 rounded-md text-sm sm:text-base font-medium transition-colors
-               border border-blue-500/60 text-blue-600 dark:text-blue-300 hover:bg-blue-500/10 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
+               border border-accent/60 text-accent hover:bg-accent/10 focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2"
       >
         Play Random
       </button>
@@ -47,14 +47,13 @@
         placeholder="Search sounds..."
         autofocus
         phx-debounce="400"
-        class="block w-full rounded-md border-gray-300 dark:border-gray-700 shadow-sm pl-4 pr-10 py-2
-               focus:border-blue-500 focus:ring-blue-500 sm:text-sm
-               dark:bg-gray-800 dark:text-gray-100 dark:placeholder-gray-400"
+        class="block w-full rounded-theme border-line bg-surface pl-4 pr-10 py-2 text-ink shadow-sm
+               placeholder:text-muted focus:border-accent focus:ring-accent sm:text-sm"
         autocomplete="off"
       />
       <div class="absolute inset-y-0 right-0 flex items-center pr-3">
         <svg
-          class="search-icon h-5 w-5 text-gray-400 dark:text-gray-500"
+          class="search-icon h-5 w-5 text-muted"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 20 20"
           fill="currentColor"
@@ -66,7 +65,7 @@
           />
         </svg>
         <svg
-          class="search-spinner hidden animate-spin h-5 w-5 text-gray-400 dark:text-gray-500"
+          class="search-spinner hidden animate-spin h-5 w-5 text-muted"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"
@@ -99,8 +98,7 @@
     <%= if length(tags) > 12 do %>
       <button
         phx-click="toggle_tag_list"
-        class="inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-medium
-               bg-gray-200 text-gray-700 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+        class="inline-flex items-center gap-1 rounded-full bg-surface-muted px-3 py-1 text-xs font-medium text-ink hover:bg-surface-raised"
       >
         {if @show_all_tags, do: "Show fewer tags", else: "Show more tags"}
       </button>
@@ -117,7 +115,7 @@
   </div>
 
   <div class="flex justify-between items-center mb-2">
-    <div class="text-sm text-gray-600 dark:text-gray-400">
+    <div class="text-sm text-muted">
       <p style="font-weight: bold">Total Sounds: {length(@uploaded_files)}</p>
     </div>
   </div>
@@ -131,7 +129,7 @@
       </div>
     <% else %>
       <%= for sound <- filter_sounds(@uploaded_files, @search_query, @selected_tags) do %>
-        <div class="relative bg-white dark:bg-gray-800 rounded-lg shadow hover:shadow-md transition-all duration-200">
+        <div class="relative rounded-theme border border-line bg-surface shadow-theme transition-all duration-200 hover:-translate-y-0.5">
           <%!-- Make the whole card clickable --%>
           <button
             phx-click="play"
@@ -147,11 +145,11 @@
           <div class="relative z-10 p-4 flex flex-col min-h-[120px] pointer-events-none">
             <%!-- Sound title and uploader info --%>
             <div class="flex-1 min-w-0">
-              <div class="text-gray-800 dark:text-gray-200 font-medium break-all">
+              <div class="text-ink font-medium break-all">
                 {display_name(sound.filename)}
               </div>
               <%= if sound.user && sound.user.username do %>
-                <div class="text-xs text-gray-500 dark:text-gray-400">
+                <div class="text-xs text-muted">
                   Uploaded by {sound.user.username}
                 </div>
               <% end %>

--- a/lib/soundboard_web/live/soundboard_live.html.heex
+++ b/lib/soundboard_web/live/soundboard_live.html.heex
@@ -1,6 +1,6 @@
 <div class="theme-page mx-auto max-w-6xl px-4 py-8 text-ink">
   <div class="theme-page-header mb-8 flex flex-wrap items-start justify-between gap-4">
-    <div class="min-w-[200px] flex-1">
+    <div class="theme-page-heading min-w-[200px] flex-1">
       <div class="theme-eyebrow hidden">
         <span class="h-2 w-2 rounded-full bg-pop"></span>{length(@uploaded_files)} sounds loaded
       </div>

--- a/lib/soundboard_web/live/soundboard_live.html.heex
+++ b/lib/soundboard_web/live/soundboard_live.html.heex
@@ -1,20 +1,29 @@
-<div class="mx-auto max-w-6xl px-4 py-8 text-ink">
-  <div class="flex flex-wrap items-start justify-between gap-4 mb-8">
-    <h1 class="min-w-[200px] flex-1 font-display text-3xl font-bold text-ink desk:uppercase desk:tracking-[0.14em] retro:italic">
-      <span class="group relative cursor-default inline-block">
-        Sounds<div class="pointer-events-none fixed inset-0 opacity-0 group-hover:opacity-100 transition-all duration-300 z-[9999]">
+<div class="theme-page mx-auto max-w-6xl px-4 py-8 text-ink">
+  <div class="theme-page-header mb-8 flex flex-wrap items-start justify-between gap-4">
+    <div class="min-w-[200px] flex-1">
+      <div class="theme-eyebrow hidden">
+        <span class="h-2 w-2 rounded-full bg-pop"></span>{length(@uploaded_files)} sounds loaded
+      </div>
+      <h1 class="theme-page-title font-display text-3xl font-bold text-ink desk:uppercase desk:tracking-[0.14em]">
+        <span class="group relative inline-block cursor-default retro:hidden">
+          Sounds<div class="pointer-events-none fixed inset-0 opacity-0 group-hover:opacity-100 transition-all duration-300 z-[9999]">
           <img
-            src="/images/kubernetes.gif"
-            alt="kubernetes"
-            class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[800px] h-[800px] object-contain"
-          />
+              src="/images/kubernetes.gif"
+              alt="kubernetes"
+              class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[800px] h-[800px] object-contain"
+            />
         </div>
-      </span>
-    </h1>
-    <div class="flex flex-col sm:flex-row sm:flex-wrap sm:items-center sm:justify-end gap-2 w-full sm:w-auto">
+        </span>
+        <span class="relative hidden retro:inline-block">
+          <span class="theme-title-ghost" aria-hidden="true">SoundBored</span>
+          <span class="relative z-10">SoundBored</span>
+        </span>
+      </h1>
+    </div>
+    <div class="theme-actions flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:flex-wrap sm:items-center sm:justify-end">
       <button
         phx-click="show_upload_modal"
-        class="w-full sm:w-auto justify-center px-3 py-2 sm:px-4 sm:py-2 bg-accent text-accent-contrast font-medium rounded-md
+        class="theme-button theme-button-primary w-full sm:w-auto justify-center px-3 py-2 sm:px-4 sm:py-2 bg-accent text-accent-contrast font-medium rounded-md
                hover:brightness-110 focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 transition-colors
                dark:focus:ring-offset-gray-900 text-sm sm:text-base"
       >
@@ -22,14 +31,14 @@
       </button>
       <button
         phx-click="play_random"
-        class="w-full sm:w-auto justify-center px-3 py-2 sm:px-4 sm:py-2 rounded-md text-sm sm:text-base font-medium transition-colors
+        class="theme-button w-full sm:w-auto justify-center px-3 py-2 sm:px-4 sm:py-2 rounded-md text-sm sm:text-base font-medium transition-colors
                border border-accent/60 text-accent hover:bg-accent/10 focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2"
       >
         Play Random
       </button>
       <button
         phx-click="stop_sound"
-        class="w-full sm:w-auto justify-center px-3 py-2 sm:px-4 sm:py-2 rounded-md text-sm sm:text-base font-medium transition-colors
+        class="theme-button theme-button-pop w-full sm:w-auto justify-center px-3 py-2 sm:px-4 sm:py-2 rounded-md text-sm sm:text-base font-medium transition-colors
                border border-red-500/70 text-red-600 dark:text-red-300 hover:bg-red-500/10 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
       >
         Stop All
@@ -38,7 +47,7 @@
   </div>
 
   <%!-- Search Bar --%>
-  <div class="mb-8">
+  <div class="theme-search-wrap mb-8">
     <form phx-change="search" phx-submit="search" class="relative">
       <input
         type="text"
@@ -47,7 +56,7 @@
         placeholder="Search sounds..."
         autofocus
         phx-debounce="400"
-        class="block w-full rounded-theme border-line bg-surface pl-4 pr-10 py-2 text-ink shadow-sm
+        class="theme-search block w-full rounded-theme border-line bg-surface pl-4 pr-10 py-2 text-ink shadow-sm
                placeholder:text-muted focus:border-accent focus:ring-accent sm:text-sm"
         autocomplete="off"
       />
@@ -87,7 +96,7 @@
     else
       Enum.take(tags, 12)
     end %>
-  <div class="mb-4 flex flex-wrap gap-2 items-center sm:hidden">
+  <div class="theme-tagbar mb-4 flex flex-wrap gap-2 items-center sm:hidden">
     <%= for tag <- limited_tags do %>
       <.tag_filter_button
         tag={tag}
@@ -104,7 +113,7 @@
       </button>
     <% end %>
   </div>
-  <div class="mb-4 hidden sm:flex sm:flex-wrap sm:gap-2 sm:items-center">
+  <div class="theme-tagbar mb-4 hidden sm:flex sm:flex-wrap sm:gap-2 sm:items-center">
     <%= for tag <- tags do %>
       <.tag_filter_button
         tag={tag}
@@ -114,13 +123,13 @@
     <% end %>
   </div>
 
-  <div class="flex justify-between items-center mb-2">
+  <div class="theme-count flex justify-between items-center mb-2">
     <div class="text-sm text-muted">
       <p style="font-weight: bold">Total Sounds: {length(@uploaded_files)}</p>
     </div>
   </div>
   <%!-- Sound Grid --%>
-  <div class="grid grid-cols-1 sm:grid-cols-3 lg:grid-cols-4 gap-4">
+  <div class="theme-sound-list grid grid-cols-1 sm:grid-cols-3 lg:grid-cols-4 gap-4">
     <%= if @loading_sounds do %>
       <div class="col-span-full">
         <div class="loading-container">
@@ -128,28 +137,34 @@
         </div>
       </div>
     <% else %>
-      <%= for sound <- filter_sounds(@uploaded_files, @search_query, @selected_tags) do %>
-        <div class="relative rounded-theme border border-line bg-surface shadow-theme transition-all duration-200 hover:-translate-y-0.5">
+      <%= for {sound, rank} <-
+            filter_sounds(@uploaded_files, @search_query, @selected_tags)
+            |> Enum.with_index(1) do %>
+        <div class="theme-sound-card relative rounded-theme border border-line bg-surface shadow-theme transition-all duration-200 hover:-translate-y-0.5">
           <%!-- Make the whole card clickable --%>
           <button
             phx-click="play"
             phx-value-name={sound.filename}
-            class="absolute inset-0 w-full h-full cursor-pointer z-0
+            class="theme-sound-play absolute inset-0 w-full h-full cursor-pointer z-0
                    hover:bg-green-50 dark:hover:bg-green-900/20 rounded-lg
                    focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2
                    dark:focus:ring-offset-gray-800"
           >
           </button>
 
+          <span class="theme-sound-rank hidden pointer-events-none">
+            {rank |> Integer.to_string() |> String.pad_leading(2, "0")}
+          </span>
+
           <%!-- Content container with higher z-index --%>
-          <div class="relative z-10 p-4 flex flex-col min-h-[120px] pointer-events-none">
+          <div class="theme-sound-content relative z-10 p-4 flex flex-1 flex-col min-h-[120px] pointer-events-none">
             <%!-- Sound title and uploader info --%>
             <div class="flex-1 min-w-0">
-              <div class="text-ink font-medium break-all">
+              <div class="theme-sound-title text-ink font-medium break-all">
                 {display_name(sound.filename)}
               </div>
               <%= if sound.user && sound.user.username do %>
-                <div class="text-xs text-muted">
+                <div class="theme-sound-meta text-xs text-muted">
                   Uploaded by {sound.user.username}
                 </div>
               <% end %>
@@ -165,7 +180,7 @@
                       phx-click="toggle_tag_filter"
                       phx-value-tag={tag.name}
                       class={[
-                        "inline-flex items-center rounded-full px-2 py-1 text-xs font-medium transition-colors",
+                        "theme-sound-tag inline-flex items-center rounded-full px-2 py-1 text-xs font-medium transition-colors",
                         if(tag_selected?(tag, @selected_tags),
                           do: "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300",
                           else:
@@ -188,7 +203,7 @@
                   data-source-type={sound.source_type}
                   data-url={sound.url}
                   data-volume={sound.volume || 1.0}
-                  class="relative flex items-center justify-center w-8 h-8 text-gray-400 hover:text-green-600 
+                  class="theme-icon-button relative flex items-center justify-center w-8 h-8 text-gray-400 hover:text-green-600
                          dark:text-gray-500 dark:hover:text-green-400 rounded-md transition-colors"
                 >
                   <svg
@@ -221,7 +236,7 @@
                   <button
                     phx-click="toggle_favorite"
                     phx-value-sound-id={sound.id}
-                    class="relative flex items-center justify-center w-8 h-8 text-gray-400 hover:text-red-500 
+                    class="theme-icon-button relative flex items-center justify-center w-8 h-8 text-gray-400 hover:text-red-500
                            dark:text-gray-500 dark:hover:text-red-500 rounded-md transition-colors"
                   >
                     <%= if sound.id in @favorites do %>
@@ -234,7 +249,7 @@
                 <button
                   phx-click="edit"
                   phx-value-id={sound.id}
-                  class="relative flex items-center justify-center w-8 h-8 text-gray-400 hover:text-blue-600 
+                  class="theme-icon-button relative flex items-center justify-center w-8 h-8 text-gray-400 hover:text-blue-600
                          dark:text-gray-500 dark:hover:text-blue-400 rounded-md"
                 >
                   <svg

--- a/lib/soundboard_web/live/stats_live.ex
+++ b/lib/soundboard_web/live/stats_live.ex
@@ -121,13 +121,15 @@ defmodule SoundboardWeb.StatsLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <div id="stats" class="max-w-6xl mx-auto px-4 py-8">
+    <div id="stats" class="mx-auto max-w-6xl px-4 py-8 text-ink">
       <div class="flex justify-between items-center mb-8">
-        <h1 class="text-3xl font-bold text-gray-800 dark:text-gray-100">Stats</h1>
+        <h1 class="font-display text-3xl font-bold text-ink desk:uppercase desk:tracking-[0.14em] retro:italic">
+          Stats
+        </h1>
         <div class="flex items-center gap-4">
           <button
             phx-click="previous_week"
-            class="text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200"
+            class="text-muted hover:text-ink"
           >
             <.icon name="hero-chevron-left-solid" class="h-5 w-5" />
           </button>
@@ -135,7 +137,7 @@ defmodule SoundboardWeb.StatsLive do
             <form
               phx-change="select_week"
               phx-submit="select_week"
-              class="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400"
+              class="flex items-center gap-2 text-sm text-muted"
             >
               <label for="week-picker" class="whitespace-nowrap">
                 Week of
@@ -147,10 +149,10 @@ defmodule SoundboardWeb.StatsLive do
                 value={date_input_value(@selected_week)}
                 max={date_input_value(@current_week)}
                 phx-debounce="blur"
-                class="border border-gray-300 dark:border-gray-600 rounded-md px-2 py-1 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                class="rounded-theme border border-line bg-surface-muted px-2 py-1 text-ink focus:outline-none focus:ring-2 focus:ring-accent"
               />
             </form>
-            <span class="text-xs text-gray-500 dark:text-gray-400">
+            <span class="text-xs text-muted">
               {format_date_range(@selected_week)}
             </span>
           </div>
@@ -158,7 +160,7 @@ defmodule SoundboardWeb.StatsLive do
             phx-click="next_week"
             disabled={@selected_week == @current_week}
             class={[
-              "text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200",
+              "text-muted hover:text-ink",
               @selected_week == @current_week && "opacity-50 cursor-not-allowed"
             ]}
           >
@@ -168,8 +170,8 @@ defmodule SoundboardWeb.StatsLive do
       </div>
 
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
-        <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
-          <h2 class="text-xl font-semibold text-gray-800 dark:text-gray-100 mb-4">Top Users</h2>
+        <div class="bg-surface rounded-theme border border-line shadow-theme p-6">
+          <h2 class="text-xl font-semibold text-ink mb-4">Top Users</h2>
           <div class="space-y-2">
             <%= for {username, count} <- @top_users do %>
               <div class="flex justify-between items-center" id={"user-stat-#{username}"}>
@@ -185,28 +187,28 @@ defmodule SoundboardWeb.StatsLive do
                   />
                   {username}
                 </span>
-                <span class="text-gray-600 dark:text-gray-400">{count} plays</span>
+                <span class="text-muted">{count} plays</span>
               </div>
             <% end %>
           </div>
         </div>
 
-        <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6">
-          <h2 class="text-xl font-semibold text-gray-800 dark:text-gray-200 mb-4">Top Sounds</h2>
+        <div class="bg-surface rounded-theme border border-line shadow-theme p-6">
+          <h2 class="text-xl font-semibold text-ink mb-4">Top Sounds</h2>
           <div class="space-y-3">
             <%= for {sound_name, count} <- @top_sounds do %>
               <div
-                class="flex items-center justify-between p-2 px-6 rounded-lg bg-gray-50 dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 cursor-pointer group"
+                class="flex items-center justify-between p-2 px-6 rounded-lg bg-surface-muted hover:bg-surface-raised cursor-pointer group"
                 id={"play-top-#{sound_name}"}
                 phx-click="play_sound"
                 phx-value-sound={sound_name}
               >
                 <div class="flex items-center gap-3 min-w-0">
                   <div class="min-w-0">
-                    <p class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                    <p class="text-sm font-medium text-ink truncate">
                       {display_name(sound_name)}
                     </p>
-                    <p class="text-xs text-gray-500 dark:text-gray-400">
+                    <p class="text-xs text-muted">
                       {count} plays
                     </p>
                   </div>
@@ -217,7 +219,7 @@ defmodule SoundboardWeb.StatsLive do
                     phx-value-sound={sound_name}
                     phx-stop
                     id={"favorite-#{sound_name}"}
-                    class="text-gray-400 hover:text-red-500 dark:text-gray-500 dark:hover:text-red-500 mr-2"
+                    class="text-muted hover:text-red-500 mr-2"
                   >
                     <%= if favorite?(@favorites, sound_name, @sound_ids_by_filename) do %>
                       <.icon name="hero-heart-solid" class="h-5 w-5 text-red-500" />
@@ -233,12 +235,12 @@ defmodule SoundboardWeb.StatsLive do
       </div>
 
       <div class="mt-8 grid grid-cols-1 md:grid-cols-2 gap-8">
-        <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6">
-          <h2 class="text-xl font-semibold text-gray-800 dark:text-gray-200 mb-4">Recent Plays</h2>
+        <div class="bg-surface rounded-theme border border-line shadow-theme p-6">
+          <h2 class="text-xl font-semibold text-ink mb-4">Recent Plays</h2>
           <div class="space-y-3" id="recent_plays" phx-update="stream">
             <%= for {dom_id, play} <- @streams.recent_plays do %>
               <div
-                class="flex items-center justify-between p-2 rounded-lg bg-gray-50 dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 cursor-pointer group"
+                class="flex items-center justify-between p-2 rounded-lg bg-surface-muted hover:bg-surface-raised cursor-pointer group"
                 id={dom_id}
                 phx-click="play_sound"
                 phx-value-sound={play.filename}
@@ -252,23 +254,23 @@ defmodule SoundboardWeb.StatsLive do
                     />
                   </div>
                   <div class="min-w-0">
-                    <p class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                    <p class="text-sm font-medium text-ink truncate">
                       {display_name(play.filename)}
                     </p>
-                    <p class="text-xs text-gray-500 dark:text-gray-400">
+                    <p class="text-xs text-muted">
                       {play.username}
                     </p>
                   </div>
                 </div>
                 <div class="flex items-center gap-2">
-                  <span class="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                  <span class="text-xs text-muted whitespace-nowrap">
                     {format_timestamp(play.timestamp)}
                   </span>
                   <button
                     phx-click="toggle_favorite"
                     phx-value-sound={play.filename}
                     phx-stop
-                    class="text-gray-400 hover:text-red-500 dark:text-gray-500 dark:hover:text-red-500 mr-2"
+                    class="text-muted hover:text-red-500 mr-2"
                   >
                     <%= if favorite?(@favorites, play.filename, @sound_ids_by_filename) do %>
                       <.icon name="hero-heart-solid" class="h-5 w-5 text-red-500" />
@@ -282,14 +284,14 @@ defmodule SoundboardWeb.StatsLive do
           </div>
         </div>
 
-        <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6">
-          <h2 class="text-xl font-semibold text-gray-800 dark:text-gray-200 mb-4">
+        <div class="bg-surface rounded-theme border border-line shadow-theme p-6">
+          <h2 class="text-xl font-semibold text-ink mb-4">
             Recently Uploaded
           </h2>
           <div class="space-y-3">
             <%= for {sound_name, username, timestamp} <- @recent_uploads do %>
               <div
-                class="flex items-center justify-between p-2 px-6 rounded-lg bg-gray-50 dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 cursor-pointer group"
+                class="flex items-center justify-between p-2 px-6 rounded-lg bg-surface-muted hover:bg-surface-raised cursor-pointer group"
                 id={"play-upload-#{sound_name}"}
                 phx-click="play_sound"
                 phx-value-sound={sound_name}
@@ -303,23 +305,23 @@ defmodule SoundboardWeb.StatsLive do
                     />
                   </div>
                   <div class="min-w-0">
-                    <p class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                    <p class="text-sm font-medium text-ink truncate">
                       {display_name(sound_name)}
                     </p>
-                    <p class="text-xs text-gray-500 dark:text-gray-400">
+                    <p class="text-xs text-muted">
                       {username}
                     </p>
                   </div>
                 </div>
                 <div class="flex items-center gap-2">
-                  <span class="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                  <span class="text-xs text-muted whitespace-nowrap">
                     {format_timestamp(timestamp)}
                   </span>
                   <button
                     phx-click="toggle_favorite"
                     phx-value-sound={sound_name}
                     phx-stop
-                    class="text-gray-400 hover:text-red-500 dark:text-gray-500 dark:hover:text-red-500 mr-2"
+                    class="text-muted hover:text-red-500 mr-2"
                   >
                     <%= if favorite?(@favorites, sound_name, @sound_ids_by_filename) do %>
                       <.icon name="hero-heart-solid" class="h-5 w-5 text-red-500" />

--- a/test/soundboard/migrations/data_migrations_test.exs
+++ b/test/soundboard/migrations/data_migrations_test.exs
@@ -1,3 +1,6 @@
+ignore_module_conflict? = Code.compiler_options()[:ignore_module_conflict]
+Code.compiler_options(ignore_module_conflict: true)
+
 for migration_file <- [
       "20250101213201_create_sounds.exs",
       "20250101213717_create_tags.exs",
@@ -12,6 +15,8 @@ for migration_file <- [
     ] do
   Code.require_file(Path.expand("../../../priv/repo/migrations/#{migration_file}", __DIR__))
 end
+
+Code.compiler_options(ignore_module_conflict: ignore_module_conflict?)
 
 defmodule Soundboard.Migrations.DataMigrationsTest do
   use ExUnit.Case, async: false

--- a/test/soundboard_web/components/layouts/navbar_test.exs
+++ b/test/soundboard_web/components/layouts/navbar_test.exs
@@ -15,6 +15,7 @@ defmodule SoundboardWeb.Components.Layouts.NavbarTest do
       )
 
     assert html =~ "SoundBored"
+    assert html =~ "MK II"
     assert html =~ "Sounds"
     assert html =~ "Favorites"
     assert html =~ "Stats"

--- a/test/soundboard_web/live/settings_live_test.exs
+++ b/test/soundboard_web/live/settings_live_test.exs
@@ -53,6 +53,15 @@ defmodule SoundboardWeb.SettingsLiveTest do
     assert html =~ "Token values are shown"
   end
 
+  test "renders one Tailwind theme picker with all theme choices", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/settings")
+
+    assert has_element?(view, "#theme-picker")
+    assert has_element?(view, "[data-theme-choice='classic']", "Classic")
+    assert has_element?(view, "[data-theme-choice='desk']", "Studio Desk")
+    assert has_element?(view, "[data-theme-choice='retro']", "Retro Riso")
+  end
+
   test "shows upload API documentation", %{conn: conn} do
     {:ok, _view, html} = live(conn, "/settings")
 

--- a/test/soundboard_web/live/soundboard_live_test.exs
+++ b/test/soundboard_web/live/soundboard_live_test.exs
@@ -41,7 +41,7 @@ defmodule SoundboardWeb.SoundboardLiveTest do
       assert html =~ "SoundBored"
     end
 
-    test "renders shared theme hooks and ranked sound rows", %{conn: conn} do
+    test "renders shared theme hooks and ranked sound cards", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/")
 
       assert has_element?(view, ".theme-page")

--- a/test/soundboard_web/live/soundboard_live_test.exs
+++ b/test/soundboard_web/live/soundboard_live_test.exs
@@ -41,6 +41,13 @@ defmodule SoundboardWeb.SoundboardLiveTest do
       assert html =~ "SoundBored"
     end
 
+    test "renders shared theme hooks and ranked sound rows", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/")
+
+      assert has_element?(view, ".theme-page")
+      assert has_element?(view, ".theme-sound-card .theme-sound-rank", "01")
+    end
+
     test "can search sounds", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/")
 


### PR DESCRIPTION
## Summary
- replace server-side theme branching with one shared markup tree
- define Classic, Studio Desk, and Retro Riso in separate CSS files through Tailwind semantic tokens and custom variants
- match Retro to its mockup with an inked sheet, offset headline, four-column ranked cards, and misregistered-print navigation hover
- match Studio Desk to its mockup with a faceplate nav, recessed controls, hardware buttons, bank chips, dotted chassis, and responsive dark sound pads
- use 5:3 Studio pads so cards are 40% shorter than square while retaining four columns on desktop
- theme the shared flash/toast component for Classic, Studio hardware status, and Retro offset-print treatments
- import all theme definitions into one production Tailwind bundle
- persist the browser selection and apply it before paint
- suppress intentional migration module reload warnings under Elixir 1.20

## Size
- 19 files changed
- 758 additions, 146 deletions
- no theme controller, plug, assigns, or duplicated per-theme templates

## Review order

This is the first independently reviewable part of the fork changes. The YouTube feature is isolated in #77. A small integration follow-up will be submitted after both foundations land.

## Validation
- mix assets.deploy
- mix precommit
- 342 tests passed
- strict Credo passed
- ExDNA found no duplication